### PR TITLE
use bundled plotlyjs module instead of cdn link in demos

### DIFF
--- a/packages/plotly-demo/public/bar-chart.html
+++ b/packages/plotly-demo/public/bar-chart.html
@@ -21,11 +21,7 @@
     </div>
     <h1>VisAhoi Demo: Plotly - Bar Chart</h1>
     <div id="vis" style="margin-top: 560px;"></div>
-    <!--
-      Use Plotly.js via CDN, because we cannot bundle it using Snowpack.
-      See https://github.com/ffg-seva/onboarding-prototype/issues/7
-    -->
-    <!-- <script src="https://cdn.plot.ly/plotly-1.54.5.min.js"></script> -->
+
     <script type="module" src="../src/bar-chart.js"></script>
   </body>
 </html>

--- a/packages/plotly-demo/public/change-matrix.html
+++ b/packages/plotly-demo/public/change-matrix.html
@@ -21,11 +21,7 @@
     </div>
     <h1>VisAhoi Demo: Plotly - Change Matrix</h1>
     <div id="vis"></div>
-    <!--
-      Use Plotly.js via CDN, because we cannot bundle it using Snowpack.
-      See https://github.com/ffg-seva/onboarding-prototype/issues/7
-    -->
-    <!-- <script src="https://cdn.plot.ly/plotly-1.54.5.min.js"></script> -->
+
     <script type="module" src="../src/change-matrix.js"></script>
   </body>
 </html>

--- a/packages/plotly-demo/public/horizon-graph.html
+++ b/packages/plotly-demo/public/horizon-graph.html
@@ -21,11 +21,7 @@
     </div>
     <h1>VisAhoi Demo: Plotly - Horizon Graph</h1>
     <div id="vis"></div>
-    <!--
-      Use Plotly.js via CDN, because we cannot bundle it using Snowpack.
-      See https://github.com/ffg-seva/onboarding-prototype/issues/7
-    -->
-    <!-- <script src="https://cdn.plot.ly/plotly-1.54.5.min.js"></script> -->
+
     <script type="module" src="../src/horizon-graph.js"></script>
   </body>
 </html>

--- a/packages/plotly-demo/public/scatterplot.html
+++ b/packages/plotly-demo/public/scatterplot.html
@@ -21,12 +21,7 @@
     </div>
     <h1>VisAhoi Demo: Plotly - Scatterplot</h1>
     <div id="vis"></div>
-    <!--
-      Use Plotly.js via CDN, because we cannot bundle it using Snowpack.
-      See https://github.com/ffg-seva/onboarding-prototype/issues/7
-    -->
-    <!-- <script src="https://cdn.plot.ly/plotly-1.54.5.min.js"></script> -->
-    <script type="module" src="../src/scatterplot.js"></script>
 
+    <script type="module" src="../src/scatterplot.js"></script>
   </body>
 </html>


### PR DESCRIPTION
As we don't use snowpack anymore, we can use the bundled plotly.js module instead of the cdn link now.