### PR TITLE
Fixed the issues when the chart is null

### DIFF
--- a/packages/plotly/src/horizon-graph.ts
+++ b/packages/plotly/src/horizon-graph.ts
@@ -13,9 +13,10 @@ function extractOnboardingSpec(chart: any, coords): IOnboardingHorizonGraphSpec 
   const areaNodesData = Array.from(areaNodes).map((point: any) => point.__data__);
 
   const t = areaNodesData[0][0].trace;
-  // const t = undefined;
-  if (t === undefined) {    
-    return {
+  
+  if (t === undefined || t === null)  {
+    console.error('The trace is null or undefined, therefore cannot render all the onboarding messages');    
+    return {      
       chartTitle: {
         value: chart.layout.title.text,
         anchor: {

--- a/packages/plotly/src/horizon-graph.ts
+++ b/packages/plotly/src/horizon-graph.ts
@@ -15,7 +15,7 @@ function extractOnboardingSpec(chart: any, coords): IOnboardingHorizonGraphSpec 
   const t = areaNodesData[0][0].trace;
   
   if (t === undefined || t === null)  {
-    console.error('The trace is null or undefined, therefore cannot render all the onboarding messages');    
+    console.error('The trace is null or undefined, therefore not all onboarding messages can be shown');    
     return {      
       chartTitle: {
         value: chart.layout.title.text,

--- a/packages/plotly/src/horizon-graph.ts
+++ b/packages/plotly/src/horizon-graph.ts
@@ -26,8 +26,8 @@ function extractOnboardingSpec(chart: any, coords): IOnboardingHorizonGraphSpec 
       value: "area",
       anchor: {
         coords: {
-          x: (t._polygons[0].xmax / 2),
-          y: t._polygons[0].ymax,
+          x: (t?._polygons[0].xmax / 2),
+          y: t?._polygons[0].ymax,
         }
       },
     },
@@ -47,8 +47,8 @@ function extractOnboardingSpec(chart: any, coords): IOnboardingHorizonGraphSpec 
       value: chart.layout.xaxis.title.text,
       anchor: {
         coords: {
-          x: (t._polygons[0].xmax / 3*2),
-          y: (t._polygons[0].ymax / 3*2),
+          x: (t?._polygons[0].xmax / 3*2),
+          y: (t?._polygons[0].ymax / 3*2),
         }
       }
     },

--- a/packages/plotly/src/horizon-graph.ts
+++ b/packages/plotly/src/horizon-graph.ts
@@ -15,7 +15,7 @@ function extractOnboardingSpec(chart: any, coords): IOnboardingHorizonGraphSpec 
   const t = areaNodesData[0][0].trace;
   
   if (t === undefined || t === null)  {
-    console.error('The trace is null or undefined, therefore not all onboarding messages can be shown');    
+    console.error('Error: The trace is null or undefined, therefore not all onboarding messages can be shown.');    
     return {      
       chartTitle: {
         value: chart.layout.title.text,

--- a/packages/plotly/src/horizon-graph.ts
+++ b/packages/plotly/src/horizon-graph.ts
@@ -13,6 +13,18 @@ function extractOnboardingSpec(chart: any, coords): IOnboardingHorizonGraphSpec 
   const areaNodesData = Array.from(areaNodes).map((point: any) => point.__data__);
 
   const t = areaNodesData[0][0].trace;
+  // const t = undefined;
+  if (t === undefined) {    
+    return {
+      chartTitle: {
+        value: chart.layout.title.text,
+        anchor: {
+          findDomNodeByValue: true,
+          offset: {left: -20, top: 10}
+        }
+      },
+  }
+}
 
   return {
     chartTitle: {
@@ -26,8 +38,8 @@ function extractOnboardingSpec(chart: any, coords): IOnboardingHorizonGraphSpec 
       value: "area",
       anchor: {
         coords: {
-          x: (t?._polygons[0].xmax / 2),
-          y: t?._polygons[0].ymax,
+          x: (t._polygons[0].xmax / 2),
+          y: t._polygons[0].ymax,
         }
       },
     },
@@ -47,8 +59,8 @@ function extractOnboardingSpec(chart: any, coords): IOnboardingHorizonGraphSpec 
       value: chart.layout.xaxis.title.text,
       anchor: {
         coords: {
-          x: (t?._polygons[0].xmax / 3*2),
-          y: (t?._polygons[0].ymax / 3*2),
+          x: (t._polygons[0].xmax / 3*2),
+          y: (t._polygons[0].ymax / 3*2),
         }
       }
     },
@@ -65,6 +77,6 @@ function extractOnboardingSpec(chart: any, coords): IOnboardingHorizonGraphSpec 
 }
 
 export function horizonGraphFactory(chart, coords, visElementId: Element): IOnboardingMessage[] {
-  const onbordingSpec = extractOnboardingSpec(chart, coords);
+  const onbordingSpec = extractOnboardingSpec(chart, coords);  
   return generateMessages(EVisualizationType.HORIZON_GRAPH, onbordingSpec, visElementId);
 }

--- a/packages/plotly/src/index.ts
+++ b/packages/plotly/src/index.ts
@@ -36,7 +36,7 @@ export const generateBasicAnnotations = (
 
   if (chart === null) {
     console.error("Chart cannot be null");
-    return null;
+    return [];
   }
 
   // TODO: coords


### PR DESCRIPTION
Closes #110

Summary:
* Console message is disabled that the chart cannot be empty.
* The generateBasicAnnotations return just an empty array.