### PR TITLE
Onboarding does not work without chart title

### DIFF
--- a/packages/core/src/bar-chart.ts
+++ b/packages/core/src/bar-chart.ts
@@ -35,8 +35,8 @@ function generateMessages(
   const interacting = defaultOnboardingStages.get(
     EDefaultOnboardingStages.USING
   ) as IOnboardingStage;
-  let messages: IOnboardingMessage[];
-  messages = [
+
+  const messages: IOnboardingMessage[] = [
     {
       anchor: getAnchor(spec.type, visElement),
       requires: ["type"],

--- a/packages/core/src/bar-chart.ts
+++ b/packages/core/src/bar-chart.ts
@@ -1,5 +1,13 @@
-import {ISpecProp, IOnboardingSpec, IOnboardingMessage, EDefaultOnboardingStages, defaultOnboardingStages, IOnboardingStage, IAhoiConfig} from './interfaces';
-import {getAnchor} from './utils';
+import {
+  ISpecProp,
+  IOnboardingSpec,
+  IOnboardingMessage,
+  EDefaultOnboardingStages,
+  defaultOnboardingStages,
+  IOnboardingStage,
+  IAhoiConfig,
+} from "./interfaces";
+import { getAnchor } from "./utils";
 
 export interface IOnboardingBarChartSpec extends IOnboardingSpec {
   chartTitle?: ISpecProp;
@@ -16,76 +24,89 @@ export interface IOnboardingBarChartSpec extends IOnboardingSpec {
   yAxisTitle?: ISpecProp;
 }
 
-function generateMessages(spec: IOnboardingBarChartSpec, visElement: Element, ahoiConfig?: IAhoiConfig): IOnboardingMessage[] {
-  const reading = defaultOnboardingStages.get(EDefaultOnboardingStages.READING) as IOnboardingStage;
-  const interacting = defaultOnboardingStages.get(EDefaultOnboardingStages.USING) as IOnboardingStage;
+function generateMessages(
+  spec: IOnboardingBarChartSpec,
+  visElement: Element,
+  ahoiConfig?: IAhoiConfig
+): IOnboardingMessage[] {
+  const reading = defaultOnboardingStages.get(
+    EDefaultOnboardingStages.READING
+  ) as IOnboardingStage;
+  const interacting = defaultOnboardingStages.get(
+    EDefaultOnboardingStages.USING
+  ) as IOnboardingStage;
   const messages: IOnboardingMessage[] = [
     {
       anchor: getAnchor(spec.chartTitle, visElement),
-      requires: ['chartTitle'],
+      requires: ["chartTitle"],
       text: `The <span class="hT">chart shows the ${spec.chartTitle?.value}.`,
-      title: 'Reading the chart',
+      title: "Reading the chart",
       onboardingStage: reading,
       marker: {
-        id: "unique-marker-id-1"
-      }
+        id: "unique-marker-id-1",
+      },
     },
     {
       anchor: getAnchor(spec.type, visElement),
-      requires: ['type'],
+      requires: ["type"],
       text: `Each ${spec.type?.value} represents a data item.`,
-      title: 'Reading the chart',
+      title: "Reading the chart",
       onboardingStage: reading,
       marker: {
-        id: "unique-marker-id-2"
-      }
+        id: "unique-marker-id-2",
+      },
     },
     {
       anchor: getAnchor(spec.yAxisTitle, visElement),
-      requires: ['type', 'barLength', 'yAxisTitle', 'xAxisTitle'],
+      requires: ["type", "barLength", "yAxisTitle", "xAxisTitle"],
       text: `The ${spec.barLength?.value} of each ${spec.type?.value} shows e.g., the ${spec.yAxisTitle?.value} (y-axis) for a certain ${spec.xAxisTitle?.value}.`,
-      title: 'Reading the chart',
+      title: "Reading the chart",
       onboardingStage: reading,
       marker: {
-        id: "unique-marker-id-3"
-      }
+        id: "unique-marker-id-3",
+      },
     },
     {
       anchor: getAnchor(spec.xAxisTitle, visElement),
-      requires: ['type', 'xAxisOrientation', 'xAxisTitle'],
+      requires: ["type", "xAxisOrientation", "xAxisTitle"],
       text: `The ${spec.xAxisOrientation?.value} position of each ${spec.type?.value} represents the ${spec.xAxisTitle?.value} (x-axis).`,
-      title: 'Reading the chart',
+      title: "Reading the chart",
       onboardingStage: reading,
       marker: {
-        id: "unique-marker-id-4"
-      }
+        id: "unique-marker-id-4",
+      },
     },
     {
       anchor: getAnchor(spec.yMin, visElement),
-      requires: ['yAxisTitle', 'yMin'],
+      requires: ["yAxisTitle", "yMin"],
       text: `The minimum ${spec.yAxisTitle?.value} is ${spec.yMin?.value}.`,
-      title: 'Interacting with the chart',
+      title: "Interacting with the chart",
       onboardingStage: interacting,
       marker: {
-        id: "unique-marker-id-5"
-      }
+        id: "unique-marker-id-5",
+      },
     },
     {
       anchor: getAnchor(spec.yMax, visElement),
-      requires: ['yAxisTitle', 'yMax'],
+      requires: ["yAxisTitle", "yMax"],
       text: `The <span class="hT">maximum</span> ${spec.yAxisTitle?.value} is ${spec.yMax?.value}.`,
-      title: 'Interacting with the chart',
+      title: "Interacting with the chart",
       onboardingStage: interacting,
       marker: {
-        id: "unique-marker-id-6"
-      }
+        id: "unique-marker-id-6",
+      },
     },
   ];
 
+  if (spec.chartTitle?.value === undefined) {
+    messages.splice(0, 1);
+  }
   // Filter for messages where all template variables are available in the spec
-  return messages.filter((message) => message.requires.every((tplVars) => spec[tplVars]));
-};
+  return messages.filter((message) =>
+    message.requires.every((tplVars) => spec[tplVars])
+  );
+}
 
 export const barChart = {
-  generateMessages
-}
+  generateMessages,
+};

--- a/packages/core/src/bar-chart.ts
+++ b/packages/core/src/bar-chart.ts
@@ -36,123 +36,70 @@ function generateMessages(
     EDefaultOnboardingStages.USING
   ) as IOnboardingStage;
   let messages: IOnboardingMessage[];
+  messages = [
+    {
+      anchor: getAnchor(spec.type, visElement),
+      requires: ["type"],
+      text: `Each ${spec.type?.value} represents a data item.`,
+      title: "Reading the chart",
+      onboardingStage: reading,
+      marker: {
+        id: "unique-marker-id-2",
+      },
+    },
+    {
+      anchor: getAnchor(spec.yAxisTitle, visElement),
+      requires: ["type", "barLength", "yAxisTitle", "xAxisTitle"],
+      text: `The ${spec.barLength?.value} of each ${spec.type?.value} shows e.g., the ${spec.yAxisTitle?.value} (y-axis) for a certain ${spec.xAxisTitle?.value}.`,
+      title: "Reading the chart",
+      onboardingStage: reading,
+      marker: {
+        id: "unique-marker-id-3",
+      },
+    },
+    {
+      anchor: getAnchor(spec.xAxisTitle, visElement),
+      requires: ["type", "xAxisOrientation", "xAxisTitle"],
+      text: `The ${spec.xAxisOrientation?.value} position of each ${spec.type?.value} represents the ${spec.xAxisTitle?.value} (x-axis).`,
+      title: "Reading the chart",
+      onboardingStage: reading,
+      marker: {
+        id: "unique-marker-id-4",
+      },
+    },
+    {
+      anchor: getAnchor(spec.yMin, visElement),
+      requires: ["yAxisTitle", "yMin"],
+      text: `The minimum ${spec.yAxisTitle?.value} is ${spec.yMin?.value}.`,
+      title: "Interacting with the chart",
+      onboardingStage: interacting,
+      marker: {
+        id: "unique-marker-id-5",
+      },
+    },
+    {
+      anchor: getAnchor(spec.yMax, visElement),
+      requires: ["yAxisTitle", "yMax"],
+      text: `The <span class="hT">maximum</span> ${spec.yAxisTitle?.value} is ${spec.yMax?.value}.`,
+      title: "Interacting with the chart",
+      onboardingStage: interacting,
+      marker: {
+        id: "unique-marker-id-6",
+      },
+    },
+  ];
 
-  if (spec.chartTitle?.value === undefined) {
-    messages = [
-      {
-        anchor: getAnchor(spec.type, visElement),
-        requires: ["type"],
-        text: `Each ${spec.type?.value} represents a data item.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-1",
-        },
+  if (spec.chartTitle?.value !== undefined) {
+    messages.unshift({
+      anchor: getAnchor(spec.chartTitle, visElement),
+      requires: ["chartTitle"],
+      text: `The <span class="hT">chart shows the ${spec.chartTitle?.value}.`,
+      title: "Reading the chart",
+      onboardingStage: reading,
+      marker: {
+        id: "unique-marker-id-1",
       },
-      {
-        anchor: getAnchor(spec.yAxisTitle, visElement),
-        requires: ["type", "barLength", "yAxisTitle", "xAxisTitle"],
-        text: `The ${spec.barLength?.value} of each ${spec.type?.value} shows e.g., the ${spec.yAxisTitle?.value} (y-axis) for a certain ${spec.xAxisTitle?.value}.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-2",
-        },
-      },
-      {
-        anchor: getAnchor(spec.xAxisTitle, visElement),
-        requires: ["type", "xAxisOrientation", "xAxisTitle"],
-        text: `The ${spec.xAxisOrientation?.value} position of each ${spec.type?.value} represents the ${spec.xAxisTitle?.value} (x-axis).`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-3",
-        },
-      },
-      {
-        anchor: getAnchor(spec.yMin, visElement),
-        requires: ["yAxisTitle", "yMin"],
-        text: `The minimum ${spec.yAxisTitle?.value} is ${spec.yMin?.value}.`,
-        title: "Interacting with the chart",
-        onboardingStage: interacting,
-        marker: {
-          id: "unique-marker-id-4",
-        },
-      },
-      {
-        anchor: getAnchor(spec.yMax, visElement),
-        requires: ["yAxisTitle", "yMax"],
-        text: `The <span class="hT">maximum</span> ${spec.yAxisTitle?.value} is ${spec.yMax?.value}.`,
-        title: "Interacting with the chart",
-        onboardingStage: interacting,
-        marker: {
-          id: "unique-marker-id-5",
-        },
-      },
-    ];
-  } else {
-    messages = [
-      {
-        anchor: getAnchor(spec.chartTitle, visElement),
-        requires: ["chartTitle"],
-        text: `The <span class="hT">chart shows the ${spec.chartTitle?.value}.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-1",
-        },
-      },
-      {
-        anchor: getAnchor(spec.type, visElement),
-        requires: ["type"],
-        text: `Each ${spec.type?.value} represents a data item.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-2",
-        },
-      },
-      {
-        anchor: getAnchor(spec.yAxisTitle, visElement),
-        requires: ["type", "barLength", "yAxisTitle", "xAxisTitle"],
-        text: `The ${spec.barLength?.value} of each ${spec.type?.value} shows e.g., the ${spec.yAxisTitle?.value} (y-axis) for a certain ${spec.xAxisTitle?.value}.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-3",
-        },
-      },
-      {
-        anchor: getAnchor(spec.xAxisTitle, visElement),
-        requires: ["type", "xAxisOrientation", "xAxisTitle"],
-        text: `The ${spec.xAxisOrientation?.value} position of each ${spec.type?.value} represents the ${spec.xAxisTitle?.value} (x-axis).`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-4",
-        },
-      },
-      {
-        anchor: getAnchor(spec.yMin, visElement),
-        requires: ["yAxisTitle", "yMin"],
-        text: `The minimum ${spec.yAxisTitle?.value} is ${spec.yMin?.value}.`,
-        title: "Interacting with the chart",
-        onboardingStage: interacting,
-        marker: {
-          id: "unique-marker-id-5",
-        },
-      },
-      {
-        anchor: getAnchor(spec.yMax, visElement),
-        requires: ["yAxisTitle", "yMax"],
-        text: `The <span class="hT">maximum</span> ${spec.yAxisTitle?.value} is ${spec.yMax?.value}.`,
-        title: "Interacting with the chart",
-        onboardingStage: interacting,
-        marker: {
-          id: "unique-marker-id-6",
-        },
-      },
-    ];
+    });
   }
 
   // Filter for messages where all template variables are available in the spec

--- a/packages/core/src/bar-chart.ts
+++ b/packages/core/src/bar-chart.ts
@@ -35,72 +35,126 @@ function generateMessages(
   const interacting = defaultOnboardingStages.get(
     EDefaultOnboardingStages.USING
   ) as IOnboardingStage;
-  const messages: IOnboardingMessage[] = [
-    {
-      anchor: getAnchor(spec.chartTitle, visElement),
-      requires: ["chartTitle"],
-      text: `The <span class="hT">chart shows the ${spec.chartTitle?.value}.`,
-      title: "Reading the chart",
-      onboardingStage: reading,
-      marker: {
-        id: "unique-marker-id-1",
-      },
-    },
-    {
-      anchor: getAnchor(spec.type, visElement),
-      requires: ["type"],
-      text: `Each ${spec.type?.value} represents a data item.`,
-      title: "Reading the chart",
-      onboardingStage: reading,
-      marker: {
-        id: "unique-marker-id-2",
-      },
-    },
-    {
-      anchor: getAnchor(spec.yAxisTitle, visElement),
-      requires: ["type", "barLength", "yAxisTitle", "xAxisTitle"],
-      text: `The ${spec.barLength?.value} of each ${spec.type?.value} shows e.g., the ${spec.yAxisTitle?.value} (y-axis) for a certain ${spec.xAxisTitle?.value}.`,
-      title: "Reading the chart",
-      onboardingStage: reading,
-      marker: {
-        id: "unique-marker-id-3",
-      },
-    },
-    {
-      anchor: getAnchor(spec.xAxisTitle, visElement),
-      requires: ["type", "xAxisOrientation", "xAxisTitle"],
-      text: `The ${spec.xAxisOrientation?.value} position of each ${spec.type?.value} represents the ${spec.xAxisTitle?.value} (x-axis).`,
-      title: "Reading the chart",
-      onboardingStage: reading,
-      marker: {
-        id: "unique-marker-id-4",
-      },
-    },
-    {
-      anchor: getAnchor(spec.yMin, visElement),
-      requires: ["yAxisTitle", "yMin"],
-      text: `The minimum ${spec.yAxisTitle?.value} is ${spec.yMin?.value}.`,
-      title: "Interacting with the chart",
-      onboardingStage: interacting,
-      marker: {
-        id: "unique-marker-id-5",
-      },
-    },
-    {
-      anchor: getAnchor(spec.yMax, visElement),
-      requires: ["yAxisTitle", "yMax"],
-      text: `The <span class="hT">maximum</span> ${spec.yAxisTitle?.value} is ${spec.yMax?.value}.`,
-      title: "Interacting with the chart",
-      onboardingStage: interacting,
-      marker: {
-        id: "unique-marker-id-6",
-      },
-    },
-  ];
+  let messages: IOnboardingMessage[];
 
   if (spec.chartTitle?.value === undefined) {
-    messages.splice(0, 1);
+    messages = [
+      {
+        anchor: getAnchor(spec.type, visElement),
+        requires: ["type"],
+        text: `Each ${spec.type?.value} represents a data item.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-1",
+        },
+      },
+      {
+        anchor: getAnchor(spec.yAxisTitle, visElement),
+        requires: ["type", "barLength", "yAxisTitle", "xAxisTitle"],
+        text: `The ${spec.barLength?.value} of each ${spec.type?.value} shows e.g., the ${spec.yAxisTitle?.value} (y-axis) for a certain ${spec.xAxisTitle?.value}.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-2",
+        },
+      },
+      {
+        anchor: getAnchor(spec.xAxisTitle, visElement),
+        requires: ["type", "xAxisOrientation", "xAxisTitle"],
+        text: `The ${spec.xAxisOrientation?.value} position of each ${spec.type?.value} represents the ${spec.xAxisTitle?.value} (x-axis).`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-3",
+        },
+      },
+      {
+        anchor: getAnchor(spec.yMin, visElement),
+        requires: ["yAxisTitle", "yMin"],
+        text: `The minimum ${spec.yAxisTitle?.value} is ${spec.yMin?.value}.`,
+        title: "Interacting with the chart",
+        onboardingStage: interacting,
+        marker: {
+          id: "unique-marker-id-4",
+        },
+      },
+      {
+        anchor: getAnchor(spec.yMax, visElement),
+        requires: ["yAxisTitle", "yMax"],
+        text: `The <span class="hT">maximum</span> ${spec.yAxisTitle?.value} is ${spec.yMax?.value}.`,
+        title: "Interacting with the chart",
+        onboardingStage: interacting,
+        marker: {
+          id: "unique-marker-id-5",
+        },
+      },
+    ];
+  } else {
+    messages = [
+      {
+        anchor: getAnchor(spec.chartTitle, visElement),
+        requires: ["chartTitle"],
+        text: `The <span class="hT">chart shows the ${spec.chartTitle?.value}.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-1",
+        },
+      },
+      {
+        anchor: getAnchor(spec.type, visElement),
+        requires: ["type"],
+        text: `Each ${spec.type?.value} represents a data item.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-2",
+        },
+      },
+      {
+        anchor: getAnchor(spec.yAxisTitle, visElement),
+        requires: ["type", "barLength", "yAxisTitle", "xAxisTitle"],
+        text: `The ${spec.barLength?.value} of each ${spec.type?.value} shows e.g., the ${spec.yAxisTitle?.value} (y-axis) for a certain ${spec.xAxisTitle?.value}.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-3",
+        },
+      },
+      {
+        anchor: getAnchor(spec.xAxisTitle, visElement),
+        requires: ["type", "xAxisOrientation", "xAxisTitle"],
+        text: `The ${spec.xAxisOrientation?.value} position of each ${spec.type?.value} represents the ${spec.xAxisTitle?.value} (x-axis).`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-4",
+        },
+      },
+      {
+        anchor: getAnchor(spec.yMin, visElement),
+        requires: ["yAxisTitle", "yMin"],
+        text: `The minimum ${spec.yAxisTitle?.value} is ${spec.yMin?.value}.`,
+        title: "Interacting with the chart",
+        onboardingStage: interacting,
+        marker: {
+          id: "unique-marker-id-5",
+        },
+      },
+      {
+        anchor: getAnchor(spec.yMax, visElement),
+        requires: ["yAxisTitle", "yMax"],
+        text: `The <span class="hT">maximum</span> ${spec.yAxisTitle?.value} is ${spec.yMax?.value}.`,
+        title: "Interacting with the chart",
+        onboardingStage: interacting,
+        marker: {
+          id: "unique-marker-id-6",
+        },
+      },
+    ];
   }
+
   // Filter for messages where all template variables are available in the spec
   return messages.filter((message) =>
     message.requires.every((tplVars) => spec[tplVars])

--- a/packages/core/src/change-matrix.ts
+++ b/packages/core/src/change-matrix.ts
@@ -1,5 +1,13 @@
-import { ISpecProp, IOnboardingSpec, IOnboardingMessage, defaultOnboardingStages, EDefaultOnboardingStages, IOnboardingStage, TooltipPosition } from "./interfaces";
-import {getAnchor} from './utils';
+import {
+  ISpecProp,
+  IOnboardingSpec,
+  IOnboardingMessage,
+  defaultOnboardingStages,
+  EDefaultOnboardingStages,
+  IOnboardingStage,
+  TooltipPosition,
+} from "./interfaces";
+import { getAnchor } from "./utils";
 
 export interface IOnboardingChangeMatrixSpec extends IOnboardingSpec {
   chartTitle?: ISpecProp;
@@ -9,61 +17,71 @@ export interface IOnboardingChangeMatrixSpec extends IOnboardingSpec {
   yAxis?: ISpecProp;
 }
 
-
-function generateMessages(spec: IOnboardingChangeMatrixSpec, visElement: Element): IOnboardingMessage[] {
-  const reading = defaultOnboardingStages.get(EDefaultOnboardingStages.READING) as IOnboardingStage;
+function generateMessages(
+  spec: IOnboardingChangeMatrixSpec,
+  visElement: Element
+): IOnboardingMessage[] {
+  const reading = defaultOnboardingStages.get(
+    EDefaultOnboardingStages.READING
+  ) as IOnboardingStage;
   const messages = [
     {
       anchor: getAnchor(spec.chartTitle, visElement),
-      requires: ['chartTitle'],
+      requires: ["chartTitle"],
       text: `The <span class="visahoi-tooltip-hover-text">chart</span> shows the ${spec.chartTitle?.value}.`,
-      title: 'Reading the chart',
+      title: "Reading the chart",
       onboardingStage: reading,
       tooltipPosition: "top" as TooltipPosition, // this causes the "jumping" of the tooltip when resizing
       marker: {
         radius: 8,
         content: "",
-        fontSize: '20px',
-        id: "unique-marker-id-1"
-      }
+        fontSize: "20px",
+        id: "unique-marker-id-1",
+      },
     },
     {
       anchor: getAnchor(spec.type, visElement),
-      requires: ['type'],
+      requires: ["type"],
       text: `The chart Is based on colored ${spec.type?.value} elements.`,
-      title: 'Reading the chart',
+      title: "Reading the chart",
       onboardingStage: reading,
       tooltipPosition: "left" as TooltipPosition,
       marker: {
-        id: "unique-marker-id-2"
-      }
+        id: "unique-marker-id-2",
+      },
     },
     {
       anchor: getAnchor(spec.legendTitle, visElement),
-      requires: ['legendTitle'],
+      requires: ["legendTitle"],
       text: `The legend shows the ${spec.legendTitle?.value} for the chart. The colors range from blue to white and brown.`,
-      title: 'Reading the chart',
+      title: "Reading the chart",
       onboardingStage: reading,
       marker: {
-        id: "unique-marker-id-3"
-      }
+        id: "unique-marker-id-3",
+      },
     },
     {
       anchor: getAnchor(spec.xAxis, visElement),
-      requires: ['xAxis', 'yAxis'],
+      requires: ["xAxis", "yAxis"],
       text: `The columns show the ${spec.xAxis?.value}, while the rows show the ${spec.yAxis?.value}.`,
-      title: 'Reading the chart',
+      title: "Reading the chart",
       onboardingStage: reading,
       marker: {
-        id: "unique-marker-id-4"
-      }
+        id: "unique-marker-id-4",
+      },
     },
   ];
 
+  if (spec.chartTitle?.value === undefined) {
+    messages.splice(0, 1);
+  }
+
   // Filter for messages where all template variables are available in the spec
-  return messages.filter((message) => message.requires.every((tplVars) => spec[tplVars]));
-};
+  return messages.filter((message) =>
+    message.requires.every((tplVars) => spec[tplVars])
+  );
+}
 
 export const changeMatrix = {
-  generateMessages
+  generateMessages,
 };

--- a/packages/core/src/change-matrix.ts
+++ b/packages/core/src/change-matrix.ts
@@ -24,56 +24,90 @@ function generateMessages(
   const reading = defaultOnboardingStages.get(
     EDefaultOnboardingStages.READING
   ) as IOnboardingStage;
-  const messages = [
-    {
-      anchor: getAnchor(spec.chartTitle, visElement),
-      requires: ["chartTitle"],
-      text: `The <span class="visahoi-tooltip-hover-text">chart</span> shows the ${spec.chartTitle?.value}.`,
-      title: "Reading the chart",
-      onboardingStage: reading,
-      tooltipPosition: "top" as TooltipPosition, // this causes the "jumping" of the tooltip when resizing
-      marker: {
-        radius: 8,
-        content: "",
-        fontSize: "20px",
-        id: "unique-marker-id-1",
-      },
-    },
-    {
-      anchor: getAnchor(spec.type, visElement),
-      requires: ["type"],
-      text: `The chart Is based on colored ${spec.type?.value} elements.`,
-      title: "Reading the chart",
-      onboardingStage: reading,
-      tooltipPosition: "left" as TooltipPosition,
-      marker: {
-        id: "unique-marker-id-2",
-      },
-    },
-    {
-      anchor: getAnchor(spec.legendTitle, visElement),
-      requires: ["legendTitle"],
-      text: `The legend shows the ${spec.legendTitle?.value} for the chart. The colors range from blue to white and brown.`,
-      title: "Reading the chart",
-      onboardingStage: reading,
-      marker: {
-        id: "unique-marker-id-3",
-      },
-    },
-    {
-      anchor: getAnchor(spec.xAxis, visElement),
-      requires: ["xAxis", "yAxis"],
-      text: `The columns show the ${spec.xAxis?.value}, while the rows show the ${spec.yAxis?.value}.`,
-      title: "Reading the chart",
-      onboardingStage: reading,
-      marker: {
-        id: "unique-marker-id-4",
-      },
-    },
-  ];
+  let messages: IOnboardingMessage[];
 
   if (spec.chartTitle?.value === undefined) {
-    messages.splice(0, 1);
+    messages = [
+      {
+        anchor: getAnchor(spec.type, visElement),
+        requires: ["type"],
+        text: `The chart Is based on colored ${spec.type?.value} elements.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        tooltipPosition: "left" as TooltipPosition,
+        marker: {
+          id: "unique-marker-id-1",
+        },
+      },
+      {
+        anchor: getAnchor(spec.legendTitle, visElement),
+        requires: ["legendTitle"],
+        text: `The legend shows the ${spec.legendTitle?.value} for the chart. The colors range from blue to white and brown.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-2",
+        },
+      },
+      {
+        anchor: getAnchor(spec.xAxis, visElement),
+        requires: ["xAxis", "yAxis"],
+        text: `The columns show the ${spec.xAxis?.value}, while the rows show the ${spec.yAxis?.value}.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-3",
+        },
+      },
+    ];
+  } else {
+    messages = [
+      {
+        anchor: getAnchor(spec.chartTitle, visElement),
+        requires: ["chartTitle"],
+        text: `The <span class="visahoi-tooltip-hover-text">chart</span> shows the ${spec.chartTitle?.value}.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        tooltipPosition: "top" as TooltipPosition, // this causes the "jumping" of the tooltip when resizing
+        marker: {
+          radius: 8,
+          content: "",
+          fontSize: "20px",
+          id: "unique-marker-id-1",
+        },
+      },
+      {
+        anchor: getAnchor(spec.type, visElement),
+        requires: ["type"],
+        text: `The chart Is based on colored ${spec.type?.value} elements.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        tooltipPosition: "left" as TooltipPosition,
+        marker: {
+          id: "unique-marker-id-2",
+        },
+      },
+      {
+        anchor: getAnchor(spec.legendTitle, visElement),
+        requires: ["legendTitle"],
+        text: `The legend shows the ${spec.legendTitle?.value} for the chart. The colors range from blue to white and brown.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-3",
+        },
+      },
+      {
+        anchor: getAnchor(spec.xAxis, visElement),
+        requires: ["xAxis", "yAxis"],
+        text: `The columns show the ${spec.xAxis?.value}, while the rows show the ${spec.yAxis?.value}.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-4",
+        },
+      },
+    ];
   }
 
   // Filter for messages where all template variables are available in the spec

--- a/packages/core/src/change-matrix.ts
+++ b/packages/core/src/change-matrix.ts
@@ -26,88 +26,55 @@ function generateMessages(
   ) as IOnboardingStage;
   let messages: IOnboardingMessage[];
 
-  if (spec.chartTitle?.value === undefined) {
-    messages = [
-      {
-        anchor: getAnchor(spec.type, visElement),
-        requires: ["type"],
-        text: `The chart Is based on colored ${spec.type?.value} elements.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        tooltipPosition: "left" as TooltipPosition,
-        marker: {
-          id: "unique-marker-id-1",
-        },
+  messages = [
+    {
+      anchor: getAnchor(spec.type, visElement),
+      requires: ["type"],
+      text: `The chart Is based on colored ${spec.type?.value} elements.`,
+      title: "Reading the chart",
+      onboardingStage: reading,
+      tooltipPosition: "left" as TooltipPosition,
+      marker: {
+        id: "unique-marker-id-2",
       },
-      {
-        anchor: getAnchor(spec.legendTitle, visElement),
-        requires: ["legendTitle"],
-        text: `The legend shows the ${spec.legendTitle?.value} for the chart. The colors range from blue to white and brown.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-2",
-        },
+    },
+    {
+      anchor: getAnchor(spec.legendTitle, visElement),
+      requires: ["legendTitle"],
+      text: `The legend shows the ${spec.legendTitle?.value} for the chart. The colors range from blue to white and brown.`,
+      title: "Reading the chart",
+      onboardingStage: reading,
+      marker: {
+        id: "unique-marker-id-3",
       },
-      {
-        anchor: getAnchor(spec.xAxis, visElement),
-        requires: ["xAxis", "yAxis"],
-        text: `The columns show the ${spec.xAxis?.value}, while the rows show the ${spec.yAxis?.value}.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-3",
-        },
+    },
+    {
+      anchor: getAnchor(spec.xAxis, visElement),
+      requires: ["xAxis", "yAxis"],
+      text: `The columns show the ${spec.xAxis?.value}, while the rows show the ${spec.yAxis?.value}.`,
+      title: "Reading the chart",
+      onboardingStage: reading,
+      marker: {
+        id: "unique-marker-id-4",
       },
-    ];
-  } else {
-    messages = [
-      {
-        anchor: getAnchor(spec.chartTitle, visElement),
-        requires: ["chartTitle"],
-        text: `The <span class="visahoi-tooltip-hover-text">chart</span> shows the ${spec.chartTitle?.value}.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        tooltipPosition: "top" as TooltipPosition, // this causes the "jumping" of the tooltip when resizing
-        marker: {
-          radius: 8,
-          content: "",
-          fontSize: "20px",
-          id: "unique-marker-id-1",
-        },
+    },
+  ];
+
+  if (spec.chartTitle?.value !== undefined) {
+    messages.unshift({
+      anchor: getAnchor(spec.chartTitle, visElement),
+      requires: ["chartTitle"],
+      text: `The <span class="visahoi-tooltip-hover-text">chart</span> shows the ${spec.chartTitle?.value}.`,
+      title: "Reading the chart",
+      onboardingStage: reading,
+      tooltipPosition: "top" as TooltipPosition, // this causes the "jumping" of the tooltip when resizing
+      marker: {
+        radius: 8,
+        content: "",
+        fontSize: "20px",
+        id: "unique-marker-id-1",
       },
-      {
-        anchor: getAnchor(spec.type, visElement),
-        requires: ["type"],
-        text: `The chart Is based on colored ${spec.type?.value} elements.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        tooltipPosition: "left" as TooltipPosition,
-        marker: {
-          id: "unique-marker-id-2",
-        },
-      },
-      {
-        anchor: getAnchor(spec.legendTitle, visElement),
-        requires: ["legendTitle"],
-        text: `The legend shows the ${spec.legendTitle?.value} for the chart. The colors range from blue to white and brown.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-3",
-        },
-      },
-      {
-        anchor: getAnchor(spec.xAxis, visElement),
-        requires: ["xAxis", "yAxis"],
-        text: `The columns show the ${spec.xAxis?.value}, while the rows show the ${spec.yAxis?.value}.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-4",
-        },
-      },
-    ];
+    });
   }
 
   // Filter for messages where all template variables are available in the spec

--- a/packages/core/src/change-matrix.ts
+++ b/packages/core/src/change-matrix.ts
@@ -24,9 +24,8 @@ function generateMessages(
   const reading = defaultOnboardingStages.get(
     EDefaultOnboardingStages.READING
   ) as IOnboardingStage;
-  let messages: IOnboardingMessage[];
 
-  messages = [
+  const messages: IOnboardingMessage[] = [
     {
       anchor: getAnchor(spec.type, visElement),
       requires: ["type"],

--- a/packages/core/src/horizon-graph.ts
+++ b/packages/core/src/horizon-graph.ts
@@ -1,5 +1,12 @@
-import { ISpecProp, IOnboardingSpec, IOnboardingMessage, IOnboardingStage, EDefaultOnboardingStages, defaultOnboardingStages } from "./interfaces";
-import {getAnchor} from './utils';
+import {
+  ISpecProp,
+  IOnboardingSpec,
+  IOnboardingMessage,
+  IOnboardingStage,
+  EDefaultOnboardingStages,
+  defaultOnboardingStages,
+} from "./interfaces";
+import { getAnchor } from "./utils";
 
 export interface IOnboardingHorizonGraphSpec extends IOnboardingSpec {
   chartTitle?: ISpecProp;
@@ -10,84 +17,97 @@ export interface IOnboardingHorizonGraphSpec extends IOnboardingSpec {
   negativeColor?: ISpecProp;
 }
 
-function createColorRect(color = 'white') {
+function createColorRect(color = "white") {
   return `<div class="colorRect" style="background: ${color}"></div>`;
 }
 
-function generateMessages(spec: IOnboardingHorizonGraphSpec, visElement: Element): IOnboardingMessage[] {
-  const reading = defaultOnboardingStages.get(EDefaultOnboardingStages.READING) as IOnboardingStage;
-  const using = defaultOnboardingStages.get(EDefaultOnboardingStages.USING) as IOnboardingStage;
+function generateMessages(
+  spec: IOnboardingHorizonGraphSpec,
+  visElement: Element
+): IOnboardingMessage[] {
+  const reading = defaultOnboardingStages.get(
+    EDefaultOnboardingStages.READING
+  ) as IOnboardingStage;
+  const using = defaultOnboardingStages.get(
+    EDefaultOnboardingStages.USING
+  ) as IOnboardingStage;
   const messages = [
     {
       anchor: getAnchor(spec.chartTitle, visElement),
-      requires: ['chartTitle'],
+      requires: ["chartTitle"],
       text: `The chart shows the ${spec.chartTitle?.value}.`,
-      title: 'Reading the chart',
+      title: "Reading the chart",
       onboardingStage: reading,
       marker: {
-        id: "unique-marker-id-1"
-      }
+        id: "unique-marker-id-1",
+      },
     },
     {
       anchor: getAnchor(spec.type, visElement),
-      requires: ['type'],
+      requires: ["type"],
       text: `The chart is made out of ${spec.type?.value} elements.`,
-      title: 'Reading the chart',
+      title: "Reading the chart",
       onboardingStage: reading,
       marker: {
-        id: "unique-marker-id-2"
-      }
+        id: "unique-marker-id-2",
+      },
     },
     {
       anchor: getAnchor(spec.xAxis, visElement),
-      requires: ['xAxis', 'yAxis'],
+      requires: ["xAxis", "yAxis"],
       text: `The areas illustrate the ${spec.yAxis?.value} (y-axis) over ${spec.xAxis?.value} (x-axis).`,
-      title: 'Reading the chart',
+      title: "Reading the chart",
       onboardingStage: reading,
       marker: {
-        id: "unique-marker-id-3"
-      }
+        id: "unique-marker-id-3",
+      },
     },
     {
       anchor: getAnchor(spec.positiveColor, visElement),
-      requires: ['yAxis', 'positiveColor'],
-      text: `Light ${createColorRect(spec.positiveColor?.value)} areas indicate a moderate positive ${spec.yAxis?.value} and dark
-        ${createColorRect(spec.positiveColor?.value)} areas a high positive ${spec.yAxis?.value}.`,
-      title: 'Reading the chart',
+      requires: ["yAxis", "positiveColor"],
+      text: `Light ${createColorRect(
+        spec.positiveColor?.value
+      )} areas indicate a moderate positive ${spec.yAxis?.value} and dark
+        ${createColorRect(spec.positiveColor?.value)} areas a high positive ${
+        spec.yAxis?.value
+      }.`,
+      title: "Reading the chart",
       onboardingStage: reading,
       marker: {
-        id: "unique-marker-id-4"
-      }
+        id: "unique-marker-id-4",
+      },
     },
     {
       anchor: getAnchor(spec.negativeColor, visElement),
-      requires: ['yAxis', 'negativeColor'],
-      text: `${createColorRect(spec.negativeColor?.value)} areas indicate a very low negative ${spec.yAxis?.value}.`,
-      title: 'Reading the chart',
+      requires: ["yAxis", "negativeColor"],
+      text: `${createColorRect(
+        spec.negativeColor?.value
+      )} areas indicate a very low negative ${spec.yAxis?.value}.`,
+      title: "Reading the chart",
       onboardingStage: reading,
       marker: {
-        id: "unique-marker-id-5"
-      }
+        id: "unique-marker-id-5",
+      },
     },
     {
       anchor: spec.yMin?.anchor,
-      requires: ['yAxis', 'yMin'],
+      requires: ["yAxis", "yMin"],
       text: `The <span class="hT">minimum</span> ${spec.yAxis?.value} is ${spec.yMin?.value}.`,
-      title: 'Reading the chart',
+      title: "Reading the chart",
       onboardingStage: using,
       marker: {
-        id: "unique-marker-id-6"
-      }
+        id: "unique-marker-id-6",
+      },
     },
     {
       anchor: spec.yMax?.anchor,
-      requires: ['yAxis', 'yMax'],
+      requires: ["yAxis", "yMax"],
       text: `The <span class="hT">maximum</span> ${spec.yAxis?.value} is ${spec.yMax?.value}.`,
-      title: 'Reading the chart',
+      title: "Reading the chart",
       onboardingStage: using,
       marker: {
-        id: "unique-marker-id-7"
-      }
+        id: "unique-marker-id-7",
+      },
     },
   ];
 
@@ -95,8 +115,8 @@ function generateMessages(spec: IOnboardingHorizonGraphSpec, visElement: Element
   return messages.filter((message) =>
     message.requires.every((tplVars) => spec[tplVars])
   );
-};
+}
 
 export const horizonGraph = {
-  generateMessages
-}
+  generateMessages,
+};

--- a/packages/core/src/horizon-graph.ts
+++ b/packages/core/src/horizon-graph.ts
@@ -32,157 +32,87 @@ function generateMessages(
     EDefaultOnboardingStages.USING
   ) as IOnboardingStage;
   let messages: IOnboardingMessage[];
+  messages = [
+    {
+      anchor: getAnchor(spec.type, visElement),
+      requires: ["type"],
+      text: `The chart is made out of ${spec.type?.value} elements.`,
+      title: "Reading the chart",
+      onboardingStage: reading,
+      marker: {
+        id: "unique-marker-id-2",
+      },
+    },
+    {
+      anchor: getAnchor(spec.xAxis, visElement),
+      requires: ["xAxis", "yAxis"],
+      text: `The areas illustrate the ${spec.yAxis?.value} (y-axis) over ${spec.xAxis?.value} (x-axis).`,
+      title: "Reading the chart",
+      onboardingStage: reading,
+      marker: {
+        id: "unique-marker-id-3",
+      },
+    },
+    {
+      anchor: getAnchor(spec.positiveColor, visElement),
+      requires: ["yAxis", "positiveColor"],
+      text: `Light ${createColorRect(
+        spec.positiveColor?.value
+      )} areas indicate a moderate positive ${spec.yAxis?.value} and dark
+        ${createColorRect(spec.positiveColor?.value)} areas a high positive ${
+        spec.yAxis?.value
+      }.`,
+      title: "Reading the chart",
+      onboardingStage: reading,
+      marker: {
+        id: "unique-marker-id-4",
+      },
+    },
+    {
+      anchor: getAnchor(spec.negativeColor, visElement),
+      requires: ["yAxis", "negativeColor"],
+      text: `${createColorRect(
+        spec.negativeColor?.value
+      )} areas indicate a very low negative ${spec.yAxis?.value}.`,
+      title: "Reading the chart",
+      onboardingStage: reading,
+      marker: {
+        id: "unique-marker-id-5",
+      },
+    },
+    {
+      anchor: spec.yMin?.anchor,
+      requires: ["yAxis", "yMin"],
+      text: `The <span class="hT">minimum</span> ${spec.yAxis?.value} is ${spec.yMin?.value}.`,
+      title: "Reading the chart",
+      onboardingStage: using,
+      marker: {
+        id: "unique-marker-id-6",
+      },
+    },
+    {
+      anchor: spec.yMax?.anchor,
+      requires: ["yAxis", "yMax"],
+      text: `The <span class="hT">maximum</span> ${spec.yAxis?.value} is ${spec.yMax?.value}.`,
+      title: "Reading the chart",
+      onboardingStage: using,
+      marker: {
+        id: "unique-marker-id-7",
+      },
+    },
+  ];
 
-  if (spec.chartTitle?.value === undefined) {
-    messages = [
-      {
-        anchor: getAnchor(spec.type, visElement),
-        requires: ["type"],
-        text: `The chart is made out of ${spec.type?.value} elements.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-1",
-        },
+  if (spec.chartTitle?.value !== undefined) {
+    messages.unshift({
+      anchor: getAnchor(spec.chartTitle, visElement),
+      requires: ["chartTitle"],
+      text: `The chart shows the ${spec.chartTitle?.value}.`,
+      title: "Reading the chart",
+      onboardingStage: reading,
+      marker: {
+        id: "unique-marker-id-1",
       },
-      {
-        anchor: getAnchor(spec.xAxis, visElement),
-        requires: ["xAxis", "yAxis"],
-        text: `The areas illustrate the ${spec.yAxis?.value} (y-axis) over ${spec.xAxis?.value} (x-axis).`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-2",
-        },
-      },
-      {
-        anchor: getAnchor(spec.positiveColor, visElement),
-        requires: ["yAxis", "positiveColor"],
-        text: `Light ${createColorRect(
-          spec.positiveColor?.value
-        )} areas indicate a moderate positive ${spec.yAxis?.value} and dark
-          ${createColorRect(spec.positiveColor?.value)} areas a high positive ${
-          spec.yAxis?.value
-        }.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-3",
-        },
-      },
-      {
-        anchor: getAnchor(spec.negativeColor, visElement),
-        requires: ["yAxis", "negativeColor"],
-        text: `${createColorRect(
-          spec.negativeColor?.value
-        )} areas indicate a very low negative ${spec.yAxis?.value}.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-4",
-        },
-      },
-      {
-        anchor: spec.yMin?.anchor,
-        requires: ["yAxis", "yMin"],
-        text: `The <span class="hT">minimum</span> ${spec.yAxis?.value} is ${spec.yMin?.value}.`,
-        title: "Reading the chart",
-        onboardingStage: using,
-        marker: {
-          id: "unique-marker-id-5",
-        },
-      },
-      {
-        anchor: spec.yMax?.anchor,
-        requires: ["yAxis", "yMax"],
-        text: `The <span class="hT">maximum</span> ${spec.yAxis?.value} is ${spec.yMax?.value}.`,
-        title: "Reading the chart",
-        onboardingStage: using,
-        marker: {
-          id: "unique-marker-id-6",
-        },
-      },
-    ];
-  } else {
-    messages = [
-      {
-        anchor: getAnchor(spec.chartTitle, visElement),
-        requires: ["chartTitle"],
-        text: `The chart shows the ${spec.chartTitle?.value}.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-1",
-        },
-      },
-      {
-        anchor: getAnchor(spec.type, visElement),
-        requires: ["type"],
-        text: `The chart is made out of ${spec.type?.value} elements.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-2",
-        },
-      },
-      {
-        anchor: getAnchor(spec.xAxis, visElement),
-        requires: ["xAxis", "yAxis"],
-        text: `The areas illustrate the ${spec.yAxis?.value} (y-axis) over ${spec.xAxis?.value} (x-axis).`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-3",
-        },
-      },
-      {
-        anchor: getAnchor(spec.positiveColor, visElement),
-        requires: ["yAxis", "positiveColor"],
-        text: `Light ${createColorRect(
-          spec.positiveColor?.value
-        )} areas indicate a moderate positive ${spec.yAxis?.value} and dark
-          ${createColorRect(spec.positiveColor?.value)} areas a high positive ${
-          spec.yAxis?.value
-        }.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-4",
-        },
-      },
-      {
-        anchor: getAnchor(spec.negativeColor, visElement),
-        requires: ["yAxis", "negativeColor"],
-        text: `${createColorRect(
-          spec.negativeColor?.value
-        )} areas indicate a very low negative ${spec.yAxis?.value}.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-5",
-        },
-      },
-      {
-        anchor: spec.yMin?.anchor,
-        requires: ["yAxis", "yMin"],
-        text: `The <span class="hT">minimum</span> ${spec.yAxis?.value} is ${spec.yMin?.value}.`,
-        title: "Reading the chart",
-        onboardingStage: using,
-        marker: {
-          id: "unique-marker-id-6",
-        },
-      },
-      {
-        anchor: spec.yMax?.anchor,
-        requires: ["yAxis", "yMax"],
-        text: `The <span class="hT">maximum</span> ${spec.yAxis?.value} is ${spec.yMax?.value}.`,
-        title: "Reading the chart",
-        onboardingStage: using,
-        marker: {
-          id: "unique-marker-id-7",
-        },
-      },
-    ];
+    });
   }
 
   // Filter for messages where all template variables are available in the spec

--- a/packages/core/src/horizon-graph.ts
+++ b/packages/core/src/horizon-graph.ts
@@ -31,8 +31,8 @@ function generateMessages(
   const using = defaultOnboardingStages.get(
     EDefaultOnboardingStages.USING
   ) as IOnboardingStage;
-  let messages: IOnboardingMessage[];
-  messages = [
+
+  const messages: IOnboardingMessage[] = [
     {
       anchor: getAnchor(spec.type, visElement),
       requires: ["type"],

--- a/packages/core/src/horizon-graph.ts
+++ b/packages/core/src/horizon-graph.ts
@@ -31,85 +31,159 @@ function generateMessages(
   const using = defaultOnboardingStages.get(
     EDefaultOnboardingStages.USING
   ) as IOnboardingStage;
-  const messages = [
-    {
-      anchor: getAnchor(spec.chartTitle, visElement),
-      requires: ["chartTitle"],
-      text: `The chart shows the ${spec.chartTitle?.value}.`,
-      title: "Reading the chart",
-      onboardingStage: reading,
-      marker: {
-        id: "unique-marker-id-1",
+  let messages: IOnboardingMessage[];
+
+  if (spec.chartTitle?.value === undefined) {
+    messages = [
+      {
+        anchor: getAnchor(spec.type, visElement),
+        requires: ["type"],
+        text: `The chart is made out of ${spec.type?.value} elements.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-1",
+        },
       },
-    },
-    {
-      anchor: getAnchor(spec.type, visElement),
-      requires: ["type"],
-      text: `The chart is made out of ${spec.type?.value} elements.`,
-      title: "Reading the chart",
-      onboardingStage: reading,
-      marker: {
-        id: "unique-marker-id-2",
+      {
+        anchor: getAnchor(spec.xAxis, visElement),
+        requires: ["xAxis", "yAxis"],
+        text: `The areas illustrate the ${spec.yAxis?.value} (y-axis) over ${spec.xAxis?.value} (x-axis).`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-2",
+        },
       },
-    },
-    {
-      anchor: getAnchor(spec.xAxis, visElement),
-      requires: ["xAxis", "yAxis"],
-      text: `The areas illustrate the ${spec.yAxis?.value} (y-axis) over ${spec.xAxis?.value} (x-axis).`,
-      title: "Reading the chart",
-      onboardingStage: reading,
-      marker: {
-        id: "unique-marker-id-3",
+      {
+        anchor: getAnchor(spec.positiveColor, visElement),
+        requires: ["yAxis", "positiveColor"],
+        text: `Light ${createColorRect(
+          spec.positiveColor?.value
+        )} areas indicate a moderate positive ${spec.yAxis?.value} and dark
+          ${createColorRect(spec.positiveColor?.value)} areas a high positive ${
+          spec.yAxis?.value
+        }.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-3",
+        },
       },
-    },
-    {
-      anchor: getAnchor(spec.positiveColor, visElement),
-      requires: ["yAxis", "positiveColor"],
-      text: `Light ${createColorRect(
-        spec.positiveColor?.value
-      )} areas indicate a moderate positive ${spec.yAxis?.value} and dark
-        ${createColorRect(spec.positiveColor?.value)} areas a high positive ${
-        spec.yAxis?.value
-      }.`,
-      title: "Reading the chart",
-      onboardingStage: reading,
-      marker: {
-        id: "unique-marker-id-4",
+      {
+        anchor: getAnchor(spec.negativeColor, visElement),
+        requires: ["yAxis", "negativeColor"],
+        text: `${createColorRect(
+          spec.negativeColor?.value
+        )} areas indicate a very low negative ${spec.yAxis?.value}.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-4",
+        },
       },
-    },
-    {
-      anchor: getAnchor(spec.negativeColor, visElement),
-      requires: ["yAxis", "negativeColor"],
-      text: `${createColorRect(
-        spec.negativeColor?.value
-      )} areas indicate a very low negative ${spec.yAxis?.value}.`,
-      title: "Reading the chart",
-      onboardingStage: reading,
-      marker: {
-        id: "unique-marker-id-5",
+      {
+        anchor: spec.yMin?.anchor,
+        requires: ["yAxis", "yMin"],
+        text: `The <span class="hT">minimum</span> ${spec.yAxis?.value} is ${spec.yMin?.value}.`,
+        title: "Reading the chart",
+        onboardingStage: using,
+        marker: {
+          id: "unique-marker-id-5",
+        },
       },
-    },
-    {
-      anchor: spec.yMin?.anchor,
-      requires: ["yAxis", "yMin"],
-      text: `The <span class="hT">minimum</span> ${spec.yAxis?.value} is ${spec.yMin?.value}.`,
-      title: "Reading the chart",
-      onboardingStage: using,
-      marker: {
-        id: "unique-marker-id-6",
+      {
+        anchor: spec.yMax?.anchor,
+        requires: ["yAxis", "yMax"],
+        text: `The <span class="hT">maximum</span> ${spec.yAxis?.value} is ${spec.yMax?.value}.`,
+        title: "Reading the chart",
+        onboardingStage: using,
+        marker: {
+          id: "unique-marker-id-6",
+        },
       },
-    },
-    {
-      anchor: spec.yMax?.anchor,
-      requires: ["yAxis", "yMax"],
-      text: `The <span class="hT">maximum</span> ${spec.yAxis?.value} is ${spec.yMax?.value}.`,
-      title: "Reading the chart",
-      onboardingStage: using,
-      marker: {
-        id: "unique-marker-id-7",
+    ];
+  } else {
+    messages = [
+      {
+        anchor: getAnchor(spec.chartTitle, visElement),
+        requires: ["chartTitle"],
+        text: `The chart shows the ${spec.chartTitle?.value}.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-1",
+        },
       },
-    },
-  ];
+      {
+        anchor: getAnchor(spec.type, visElement),
+        requires: ["type"],
+        text: `The chart is made out of ${spec.type?.value} elements.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-2",
+        },
+      },
+      {
+        anchor: getAnchor(spec.xAxis, visElement),
+        requires: ["xAxis", "yAxis"],
+        text: `The areas illustrate the ${spec.yAxis?.value} (y-axis) over ${spec.xAxis?.value} (x-axis).`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-3",
+        },
+      },
+      {
+        anchor: getAnchor(spec.positiveColor, visElement),
+        requires: ["yAxis", "positiveColor"],
+        text: `Light ${createColorRect(
+          spec.positiveColor?.value
+        )} areas indicate a moderate positive ${spec.yAxis?.value} and dark
+          ${createColorRect(spec.positiveColor?.value)} areas a high positive ${
+          spec.yAxis?.value
+        }.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-4",
+        },
+      },
+      {
+        anchor: getAnchor(spec.negativeColor, visElement),
+        requires: ["yAxis", "negativeColor"],
+        text: `${createColorRect(
+          spec.negativeColor?.value
+        )} areas indicate a very low negative ${spec.yAxis?.value}.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-5",
+        },
+      },
+      {
+        anchor: spec.yMin?.anchor,
+        requires: ["yAxis", "yMin"],
+        text: `The <span class="hT">minimum</span> ${spec.yAxis?.value} is ${spec.yMin?.value}.`,
+        title: "Reading the chart",
+        onboardingStage: using,
+        marker: {
+          id: "unique-marker-id-6",
+        },
+      },
+      {
+        anchor: spec.yMax?.anchor,
+        requires: ["yAxis", "yMax"],
+        text: `The <span class="hT">maximum</span> ${spec.yAxis?.value} is ${spec.yMax?.value}.`,
+        title: "Reading the chart",
+        onboardingStage: using,
+        marker: {
+          id: "unique-marker-id-7",
+        },
+      },
+    ];
+  }
 
   // Filter for messages where all template variables are available in the spec
   return messages.filter((message) =>

--- a/packages/core/src/scatterplot.ts
+++ b/packages/core/src/scatterplot.ts
@@ -32,72 +32,124 @@ function generateMessages(
   const interacting = defaultOnboardingStages.get(
     EDefaultOnboardingStages.USING
   ) as IOnboardingStage;
-
-  const messages = [
-    {
-      anchor: getAnchor(spec.chartTitle, visElement),
-      requires: ["chartTitle"],
-      text: `The chart shows the ${spec.chartTitle?.value}.`,
-      title: "Reading the chart",
-      onboardingStage: reading,
-      marker: {
-        id: "unique-marker-id-1",
-      },
-    },
-    {
-      anchor: getAnchor(spec.type, visElement),
-      requires: ["type"],
-      text: `The chart Is based on colored ${spec.type?.value} elements.`,
-      title: "Interacting with the chart",
-      onboardingStage: interacting,
-      marker: {
-        id: "unique-marker-id-2",
-      },
-    },
-    {
-      anchor: getAnchor(spec.legendTitle, visElement),
-      requires: ["legendTitle"],
-      text: `The legend shows the ${spec.legendTitle?.value} for the chart. The colors range from blue to white and brown.`,
-      title: "Reading the chart",
-      onboardingStage: reading,
-      marker: {
-        id: "unique-marker-id-3",
-      },
-    },
-    {
-      anchor: getAnchor(spec.xAxisTitle, visElement),
-      requires: ["xAxisTitle", "yAxisTitle"],
-      text: `The columns show the ${spec.xAxis?.value}, while the rows show the ${spec.yAxis?.value}.`,
-      title: "Reading the chart",
-      onboardingStage: analyzing,
-      marker: {
-        id: "unique-marker-id-4",
-      },
-    },
-    {
-      anchor: getAnchor(spec.yAxisTitle, visElement),
-      requires: ["yAxisTitle", "xAxisTitle"],
-      text: `the ${spec.yAxisTitle?.value} (y-axis) for a certain ${spec.xAxisTitle?.value}.`,
-      title: "Interacting with the chart",
-      onboardingStage: interacting,
-      marker: {
-        id: "unique-marker-id-5",
-      },
-    },
-    {
-      anchor: getAnchor(spec.maxValue, visElement),
-      requires: ["maxValue"],
-      text: `The chart Is based on colored ${spec.type?.value} elements.`,
-      title: "Reading the chart",
-      onboardingStage: reading,
-      marker: {
-        id: "unique-marker-id-6",
-      },
-    },
-  ];
+  let messages: IOnboardingMessage[];
 
   if (spec.chartTitle?.value === undefined) {
-    messages.splice(0, 1);
+    messages = [
+      {
+        anchor: getAnchor(spec.type, visElement),
+        requires: ["type"],
+        text: `The chart Is based on colored ${spec.type?.value} elements.`,
+        title: "Interacting with the chart",
+        onboardingStage: interacting,
+        marker: {
+          id: "unique-marker-id-1",
+        },
+      },
+      {
+        anchor: getAnchor(spec.legendTitle, visElement),
+        requires: ["legendTitle"],
+        text: `The legend shows the ${spec.legendTitle?.value} for the chart. The colors range from blue to white and brown.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-2",
+        },
+      },
+      {
+        anchor: getAnchor(spec.xAxisTitle, visElement),
+        requires: ["xAxisTitle", "yAxisTitle"],
+        text: `The columns show the ${spec.xAxis?.value}, while the rows show the ${spec.yAxis?.value}.`,
+        title: "Reading the chart",
+        onboardingStage: analyzing,
+        marker: {
+          id: "unique-marker-id-3",
+        },
+      },
+      {
+        anchor: getAnchor(spec.yAxisTitle, visElement),
+        requires: ["yAxisTitle", "xAxisTitle"],
+        text: `the ${spec.yAxisTitle?.value} (y-axis) for a certain ${spec.xAxisTitle?.value}.`,
+        title: "Interacting with the chart",
+        onboardingStage: interacting,
+        marker: {
+          id: "unique-marker-id-4",
+        },
+      },
+      {
+        anchor: getAnchor(spec.maxValue, visElement),
+        requires: ["maxValue"],
+        text: `The chart Is based on colored ${spec.type?.value} elements.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-5",
+        },
+      },
+    ];
+  } else {
+    messages = [
+      {
+        anchor: getAnchor(spec.chartTitle, visElement),
+        requires: ["chartTitle"],
+        text: `The chart shows the ${spec.chartTitle?.value}.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-1",
+        },
+      },
+      {
+        anchor: getAnchor(spec.type, visElement),
+        requires: ["type"],
+        text: `The chart Is based on colored ${spec.type?.value} elements.`,
+        title: "Interacting with the chart",
+        onboardingStage: interacting,
+        marker: {
+          id: "unique-marker-id-2",
+        },
+      },
+      {
+        anchor: getAnchor(spec.legendTitle, visElement),
+        requires: ["legendTitle"],
+        text: `The legend shows the ${spec.legendTitle?.value} for the chart. The colors range from blue to white and brown.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-3",
+        },
+      },
+      {
+        anchor: getAnchor(spec.xAxisTitle, visElement),
+        requires: ["xAxisTitle", "yAxisTitle"],
+        text: `The columns show the ${spec.xAxis?.value}, while the rows show the ${spec.yAxis?.value}.`,
+        title: "Reading the chart",
+        onboardingStage: analyzing,
+        marker: {
+          id: "unique-marker-id-4",
+        },
+      },
+      {
+        anchor: getAnchor(spec.yAxisTitle, visElement),
+        requires: ["yAxisTitle", "xAxisTitle"],
+        text: `the ${spec.yAxisTitle?.value} (y-axis) for a certain ${spec.xAxisTitle?.value}.`,
+        title: "Interacting with the chart",
+        onboardingStage: interacting,
+        marker: {
+          id: "unique-marker-id-5",
+        },
+      },
+      {
+        anchor: getAnchor(spec.maxValue, visElement),
+        requires: ["maxValue"],
+        text: `The chart Is based on colored ${spec.type?.value} elements.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-6",
+        },
+      },
+    ];
   }
 
   // Filter for messages where all template variables are available in the spec

--- a/packages/core/src/scatterplot.ts
+++ b/packages/core/src/scatterplot.ts
@@ -32,9 +32,8 @@ function generateMessages(
   const interacting = defaultOnboardingStages.get(
     EDefaultOnboardingStages.USING
   ) as IOnboardingStage;
-  let messages: IOnboardingMessage[];
 
-  messages = [
+  const messages: IOnboardingMessage[] = [
     {
       anchor: getAnchor(spec.type, visElement),
       requires: ["type"],

--- a/packages/core/src/scatterplot.ts
+++ b/packages/core/src/scatterplot.ts
@@ -34,122 +34,70 @@ function generateMessages(
   ) as IOnboardingStage;
   let messages: IOnboardingMessage[];
 
-  if (spec.chartTitle?.value === undefined) {
-    messages = [
-      {
-        anchor: getAnchor(spec.type, visElement),
-        requires: ["type"],
-        text: `The chart Is based on colored ${spec.type?.value} elements.`,
-        title: "Interacting with the chart",
-        onboardingStage: interacting,
-        marker: {
-          id: "unique-marker-id-1",
-        },
+  messages = [
+    {
+      anchor: getAnchor(spec.type, visElement),
+      requires: ["type"],
+      text: `The chart Is based on colored ${spec.type?.value} elements.`,
+      title: "Interacting with the chart",
+      onboardingStage: interacting,
+      marker: {
+        id: "unique-marker-id-2",
       },
-      {
-        anchor: getAnchor(spec.legendTitle, visElement),
-        requires: ["legendTitle"],
-        text: `The legend shows the ${spec.legendTitle?.value} for the chart. The colors range from blue to white and brown.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-2",
-        },
+    },
+    {
+      anchor: getAnchor(spec.legendTitle, visElement),
+      requires: ["legendTitle"],
+      text: `The legend shows the ${spec.legendTitle?.value} for the chart. The colors range from blue to white and brown.`,
+      title: "Reading the chart",
+      onboardingStage: reading,
+      marker: {
+        id: "unique-marker-id-3",
       },
-      {
-        anchor: getAnchor(spec.xAxisTitle, visElement),
-        requires: ["xAxisTitle", "yAxisTitle"],
-        text: `The columns show the ${spec.xAxis?.value}, while the rows show the ${spec.yAxis?.value}.`,
-        title: "Reading the chart",
-        onboardingStage: analyzing,
-        marker: {
-          id: "unique-marker-id-3",
-        },
+    },
+    {
+      anchor: getAnchor(spec.xAxisTitle, visElement),
+      requires: ["xAxisTitle", "yAxisTitle"],
+      text: `The columns show the ${spec.xAxis?.value}, while the rows show the ${spec.yAxis?.value}.`,
+      title: "Reading the chart",
+      onboardingStage: analyzing,
+      marker: {
+        id: "unique-marker-id-4",
       },
-      {
-        anchor: getAnchor(spec.yAxisTitle, visElement),
-        requires: ["yAxisTitle", "xAxisTitle"],
-        text: `the ${spec.yAxisTitle?.value} (y-axis) for a certain ${spec.xAxisTitle?.value}.`,
-        title: "Interacting with the chart",
-        onboardingStage: interacting,
-        marker: {
-          id: "unique-marker-id-4",
-        },
+    },
+    {
+      anchor: getAnchor(spec.yAxisTitle, visElement),
+      requires: ["yAxisTitle", "xAxisTitle"],
+      text: `the ${spec.yAxisTitle?.value} (y-axis) for a certain ${spec.xAxisTitle?.value}.`,
+      title: "Interacting with the chart",
+      onboardingStage: interacting,
+      marker: {
+        id: "unique-marker-id-5",
       },
-      {
-        anchor: getAnchor(spec.maxValue, visElement),
-        requires: ["maxValue"],
-        text: `The chart Is based on colored ${spec.type?.value} elements.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-5",
-        },
+    },
+    {
+      anchor: getAnchor(spec.maxValue, visElement),
+      requires: ["maxValue"],
+      text: `The chart Is based on colored ${spec.type?.value} elements.`,
+      title: "Reading the chart",
+      onboardingStage: reading,
+      marker: {
+        id: "unique-marker-id-6",
       },
-    ];
-  } else {
-    messages = [
-      {
-        anchor: getAnchor(spec.chartTitle, visElement),
-        requires: ["chartTitle"],
-        text: `The chart shows the ${spec.chartTitle?.value}.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-1",
-        },
+    },
+  ];
+
+  if (spec.chartTitle?.value !== undefined) {
+    messages.unshift({
+      anchor: getAnchor(spec.chartTitle, visElement),
+      requires: ["chartTitle"],
+      text: `The chart shows the ${spec.chartTitle?.value}.`,
+      title: "Reading the chart",
+      onboardingStage: reading,
+      marker: {
+        id: "unique-marker-id-1",
       },
-      {
-        anchor: getAnchor(spec.type, visElement),
-        requires: ["type"],
-        text: `The chart Is based on colored ${spec.type?.value} elements.`,
-        title: "Interacting with the chart",
-        onboardingStage: interacting,
-        marker: {
-          id: "unique-marker-id-2",
-        },
-      },
-      {
-        anchor: getAnchor(spec.legendTitle, visElement),
-        requires: ["legendTitle"],
-        text: `The legend shows the ${spec.legendTitle?.value} for the chart. The colors range from blue to white and brown.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-3",
-        },
-      },
-      {
-        anchor: getAnchor(spec.xAxisTitle, visElement),
-        requires: ["xAxisTitle", "yAxisTitle"],
-        text: `The columns show the ${spec.xAxis?.value}, while the rows show the ${spec.yAxis?.value}.`,
-        title: "Reading the chart",
-        onboardingStage: analyzing,
-        marker: {
-          id: "unique-marker-id-4",
-        },
-      },
-      {
-        anchor: getAnchor(spec.yAxisTitle, visElement),
-        requires: ["yAxisTitle", "xAxisTitle"],
-        text: `the ${spec.yAxisTitle?.value} (y-axis) for a certain ${spec.xAxisTitle?.value}.`,
-        title: "Interacting with the chart",
-        onboardingStage: interacting,
-        marker: {
-          id: "unique-marker-id-5",
-        },
-      },
-      {
-        anchor: getAnchor(spec.maxValue, visElement),
-        requires: ["maxValue"],
-        text: `The chart Is based on colored ${spec.type?.value} elements.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-6",
-        },
-      },
-    ];
+    });
   }
 
   // Filter for messages where all template variables are available in the spec

--- a/packages/core/src/scatterplot.ts
+++ b/packages/core/src/scatterplot.ts
@@ -1,5 +1,12 @@
-import { ISpecProp, IOnboardingSpec, IOnboardingMessage, defaultOnboardingStages, EDefaultOnboardingStages, IOnboardingStage } from "./interfaces";
-import {getAnchor} from './utils';
+import {
+  ISpecProp,
+  IOnboardingSpec,
+  IOnboardingMessage,
+  defaultOnboardingStages,
+  EDefaultOnboardingStages,
+  IOnboardingStage,
+} from "./interfaces";
+import { getAnchor } from "./utils";
 
 export interface IOnboardingScatterplotSpec extends IOnboardingSpec {
   chartTitle?: ISpecProp;
@@ -12,78 +19,93 @@ export interface IOnboardingScatterplotSpec extends IOnboardingSpec {
   maxValue?: ISpecProp;
 }
 
-function generateMessages(spec: IOnboardingScatterplotSpec, visElement: Element): IOnboardingMessage[] {
-  const analyzing = defaultOnboardingStages.get(EDefaultOnboardingStages.ANALYZING) as IOnboardingStage;
-  const reading = defaultOnboardingStages.get(EDefaultOnboardingStages.READING) as IOnboardingStage;
-  const interacting = defaultOnboardingStages.get(EDefaultOnboardingStages.USING) as IOnboardingStage;
+function generateMessages(
+  spec: IOnboardingScatterplotSpec,
+  visElement: Element
+): IOnboardingMessage[] {
+  const analyzing = defaultOnboardingStages.get(
+    EDefaultOnboardingStages.ANALYZING
+  ) as IOnboardingStage;
+  const reading = defaultOnboardingStages.get(
+    EDefaultOnboardingStages.READING
+  ) as IOnboardingStage;
+  const interacting = defaultOnboardingStages.get(
+    EDefaultOnboardingStages.USING
+  ) as IOnboardingStage;
 
   const messages = [
     {
       anchor: getAnchor(spec.chartTitle, visElement),
-      requires: ['chartTitle'],
+      requires: ["chartTitle"],
       text: `The chart shows the ${spec.chartTitle?.value}.`,
-      title: 'Reading the chart',
+      title: "Reading the chart",
       onboardingStage: reading,
       marker: {
-        id: "unique-marker-id-1"
-      }
+        id: "unique-marker-id-1",
+      },
     },
     {
       anchor: getAnchor(spec.type, visElement),
-      requires: ['type'],
+      requires: ["type"],
       text: `The chart Is based on colored ${spec.type?.value} elements.`,
-      title: 'Interacting with the chart',
+      title: "Interacting with the chart",
       onboardingStage: interacting,
       marker: {
-        id: "unique-marker-id-2"
-      }
+        id: "unique-marker-id-2",
+      },
     },
     {
       anchor: getAnchor(spec.legendTitle, visElement),
-      requires: ['legendTitle'],
+      requires: ["legendTitle"],
       text: `The legend shows the ${spec.legendTitle?.value} for the chart. The colors range from blue to white and brown.`,
-      title: 'Reading the chart',
+      title: "Reading the chart",
       onboardingStage: reading,
       marker: {
-        id: "unique-marker-id-3"
-      }
+        id: "unique-marker-id-3",
+      },
     },
     {
       anchor: getAnchor(spec.xAxisTitle, visElement),
-      requires: ['xAxisTitle', 'yAxisTitle'],
+      requires: ["xAxisTitle", "yAxisTitle"],
       text: `The columns show the ${spec.xAxis?.value}, while the rows show the ${spec.yAxis?.value}.`,
-      title: 'Reading the chart',
+      title: "Reading the chart",
       onboardingStage: analyzing,
       marker: {
-        id: "unique-marker-id-4"
-      }
+        id: "unique-marker-id-4",
+      },
     },
     {
       anchor: getAnchor(spec.yAxisTitle, visElement),
-      requires: ['yAxisTitle', 'xAxisTitle'],
+      requires: ["yAxisTitle", "xAxisTitle"],
       text: `the ${spec.yAxisTitle?.value} (y-axis) for a certain ${spec.xAxisTitle?.value}.`,
-      title: 'Interacting with the chart',
+      title: "Interacting with the chart",
       onboardingStage: interacting,
       marker: {
-        id: "unique-marker-id-5"
-      }
+        id: "unique-marker-id-5",
+      },
     },
     {
       anchor: getAnchor(spec.maxValue, visElement),
-      requires: ['maxValue'],
+      requires: ["maxValue"],
       text: `The chart Is based on colored ${spec.type?.value} elements.`,
-      title: 'Reading the chart',
+      title: "Reading the chart",
       onboardingStage: reading,
       marker: {
-        id: "unique-marker-id-6"
-      }
-    }
+        id: "unique-marker-id-6",
+      },
+    },
   ];
 
+  if (spec.chartTitle?.value === undefined) {
+    messages.splice(0, 1);
+  }
+
   // Filter for messages where all template variables are available in the spec
-  return messages.filter((message) => message.requires.every((tplVars) => spec[tplVars]));
-};
+  return messages.filter((message) =>
+    message.requires.every((tplVars) => spec[tplVars])
+  );
+}
 
 export const scatterplot = {
-  generateMessages
+  generateMessages,
 };

--- a/packages/core/src/treemap.ts
+++ b/packages/core/src/treemap.ts
@@ -34,8 +34,8 @@ function generateMessages(
   const interacting = defaultOnboardingStages.get(
     EDefaultOnboardingStages.USING
   ) as IOnboardingStage;
-  let messages: IOnboardingMessage[];
-  messages = [
+
+  const messages: IOnboardingMessage[] = [
     {
       anchor: getAnchor(spec.desc, visElement),
       requires: ["desc"],

--- a/packages/core/src/treemap.ts
+++ b/packages/core/src/treemap.ts
@@ -35,169 +35,93 @@ function generateMessages(
     EDefaultOnboardingStages.USING
   ) as IOnboardingStage;
   let messages: IOnboardingMessage[];
+  messages = [
+    {
+      anchor: getAnchor(spec.desc, visElement),
+      requires: ["desc"],
+      text: `The treemap visualization shows the breakdown of hierarchical data level by level.The size of each rectangle represents a quantitative value associated with each element in the hierarchy.`,
+      title: "Reading the chart",
+      onboardingStage: reading,
+      marker: {
+        id: "unique-marker-id-2",
+      },
+    },
+    {
+      anchor: getAnchor(spec.subDesc, visElement),
+      requires: ["subDesc"],
+      text: `The area covered by the whole treemap is subdivided recursively into sub-categories according to their quantitative values, level by level.`,
+      title: "Reading the chart",
+      onboardingStage: reading,
+      marker: {
+        id: "unique-marker-id-3",
+      },
+    },
+    {
+      anchor: getAnchor(spec.otherDesc, visElement),
+      requires: ["otherDesc"],
+      text: `Items on the bottom level that belong to the same sub-category are visually represented by using the same color.`,
+      title: "Reading the chart",
+      onboardingStage: reading,
+      marker: {
+        id: "unique-marker-id-4",
+      },
+    },
+    {
+      anchor: getAnchor(spec.gapDesc, visElement),
+      requires: ["gapDesc"],
+      text: `Items within a sub-category are represented by rectangles that are closely packed together with increasingly larger gaps to the neighboring categories.`,
+      title: "Reading the chart",
+      onboardingStage: reading,
+      marker: {
+        id: "unique-marker-id-5",
+      },
+    },
 
-  if (spec.chartTitle?.value === undefined) {
-    messages = [
-      {
-        anchor: getAnchor(spec.desc, visElement),
-        requires: ["desc"],
-        text: `The treemap visualization shows the breakdown of hierarchical data level by level.The size of each rectangle represents a quantitative value associated with each element in the hierarchy.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-1",
-        },
+    {
+      anchor: getAnchor(spec.interactingDesc, visElement),
+      requires: ["interactingDesc"],
+      text: `Hover over the rectangles to get the dedicated value of the sub-category and further information.`,
+      title: "Interacting with the chart",
+      onboardingStage: interacting,
+      marker: {
+        id: "unique-marker-id-6",
       },
-      {
-        anchor: getAnchor(spec.subDesc, visElement),
-        requires: ["subDesc"],
-        text: `The area covered by the whole treemap is subdivided recursively into sub-categories according to their quantitative values, level by level.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-2",
-        },
-      },
-      {
-        anchor: getAnchor(spec.otherDesc, visElement),
-        requires: ["otherDesc"],
-        text: `Items on the bottom level that belong to the same sub-category are visually represented by using the same color.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-3",
-        },
-      },
-      {
-        anchor: getAnchor(spec.gapDesc, visElement),
-        requires: ["gapDesc"],
-        text: `Items within a sub-category are represented by rectangles that are closely packed together with increasingly larger gaps to the neighboring categories.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-4",
-        },
-      },
+    },
 
-      {
-        anchor: getAnchor(spec.interactingDesc, visElement),
-        requires: ["interactingDesc"],
-        text: `Hover over the rectangles to get the dedicated value of the sub-category and further information.`,
-        title: "Interacting with the chart",
-        onboardingStage: interacting,
-        marker: {
-          id: "unique-marker-id-5",
-        },
+    {
+      anchor: getAnchor(spec.maxValueDesc, visElement),
+      requires: ["maxValueDesc", "maxValue"],
+      text: `The largest rectangle holds the maximum value in the sub-category. In this sub-category ${spec.maxValue?.value} is the maximum value.`,
+      title: "Analyzing the chart",
+      onboardingStage: analyzing,
+      marker: {
+        id: "unique-marker-id-7",
       },
+    },
 
-      {
-        anchor: getAnchor(spec.maxValueDesc, visElement),
-        requires: ["maxValueDesc", "maxValue"],
-        text: `The largest rectangle holds the maximum value in the sub-category. In this sub-category ${spec.maxValue?.value} is the maximum value.`,
-        title: "Analyzing the chart",
-        onboardingStage: analyzing,
-        marker: {
-          id: "unique-marker-id-6",
-        },
+    {
+      anchor: getAnchor(spec.minValueDesc, visElement),
+      requires: ["minValueDesc", "minValue"],
+      text: ` The smallest rectangle holds the minimum value in the sub-category. In this sub-category ${spec.minValue?.value} is the minimum value.`,
+      title: "Analyzing the chart",
+      onboardingStage: analyzing,
+      marker: {
+        id: "unique-marker-id-8",
       },
+    },
+  ];
 
-      {
-        anchor: getAnchor(spec.minValueDesc, visElement),
-        requires: ["minValueDesc", "minValue"],
-        text: ` The smallest rectangle holds the minimum value in the sub-category. In this sub-category ${spec.minValue?.value} is the minimum value.`,
-        title: "Analyzing the chart",
-        onboardingStage: analyzing,
-        marker: {
-          id: "unique-marker-id-7",
-        },
+  if (spec.chartTitle?.value !== undefined) {
+    messages.unshift({
+      anchor: getAnchor(spec.chartTitle, visElement),
+      requires: ["chartTitle"],
+      text: `The chart shows the ${spec.chartTitle?.value}.`,
+      title: "Reading the chart",
+      onboardingStage: reading,
+      marker: {
+        id: "unique-marker-id-1",
       },
-    ];
-  } else {
-    messages = [
-      {
-        anchor: getAnchor(spec.chartTitle, visElement),
-        requires: ["chartTitle"],
-        text: `The chart shows the ${spec.chartTitle?.value}.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-1",
-        },
-      },
-      {
-        anchor: getAnchor(spec.desc, visElement),
-        requires: ["desc"],
-        text: `The treemap visualization shows the breakdown of hierarchical data level by level.The size of each rectangle represents a quantitative value associated with each element in the hierarchy.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-2",
-        },
-      },
-      {
-        anchor: getAnchor(spec.subDesc, visElement),
-        requires: ["subDesc"],
-        text: `The area covered by the whole treemap is subdivided recursively into sub-categories according to their quantitative values, level by level.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-3",
-        },
-      },
-      {
-        anchor: getAnchor(spec.otherDesc, visElement),
-        requires: ["otherDesc"],
-        text: `Items on the bottom level that belong to the same sub-category are visually represented by using the same color.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-4",
-        },
-      },
-      {
-        anchor: getAnchor(spec.gapDesc, visElement),
-        requires: ["gapDesc"],
-        text: `Items within a sub-category are represented by rectangles that are closely packed together with increasingly larger gaps to the neighboring categories.`,
-        title: "Reading the chart",
-        onboardingStage: reading,
-        marker: {
-          id: "unique-marker-id-5",
-        },
-      },
-
-      {
-        anchor: getAnchor(spec.interactingDesc, visElement),
-        requires: ["interactingDesc"],
-        text: `Hover over the rectangles to get the dedicated value of the sub-category and further information.`,
-        title: "Interacting with the chart",
-        onboardingStage: interacting,
-        marker: {
-          id: "unique-marker-id-6",
-        },
-      },
-
-      {
-        anchor: getAnchor(spec.maxValueDesc, visElement),
-        requires: ["maxValueDesc", "maxValue"],
-        text: `The largest rectangle holds the maximum value in the sub-category. In this sub-category ${spec.maxValue?.value} is the maximum value.`,
-        title: "Analyzing the chart",
-        onboardingStage: analyzing,
-        marker: {
-          id: "unique-marker-id-7",
-        },
-      },
-
-      {
-        anchor: getAnchor(spec.minValueDesc, visElement),
-        requires: ["minValueDesc", "minValue"],
-        text: ` The smallest rectangle holds the minimum value in the sub-category. In this sub-category ${spec.minValue?.value} is the minimum value.`,
-        title: "Analyzing the chart",
-        onboardingStage: analyzing,
-        marker: {
-          id: "unique-marker-id-8",
-        },
-      },
-    ];
+    });
   }
 
   // Filter for messages where all template variables are available in the spec

--- a/packages/core/src/treemap.ts
+++ b/packages/core/src/treemap.ts
@@ -1,5 +1,12 @@
-import { ISpecProp, IOnboardingSpec, IOnboardingMessage, defaultOnboardingStages, EDefaultOnboardingStages, IOnboardingStage } from "./interfaces";
-import {getAnchor} from './utils';
+import {
+  ISpecProp,
+  IOnboardingSpec,
+  IOnboardingMessage,
+  defaultOnboardingStages,
+  EDefaultOnboardingStages,
+  IOnboardingStage,
+} from "./interfaces";
+import { getAnchor } from "./utils";
 
 export interface IOnboardingTreemapSpec extends IOnboardingSpec {
   chartTitle?: ISpecProp;
@@ -10,106 +17,120 @@ export interface IOnboardingTreemapSpec extends IOnboardingSpec {
   interactingDesc?: ISpecProp;
   maxValueDesc?: ISpecProp;
   minValueDesc?: ISpecProp;
-  minValue?: ISpecProp;  
+  minValue?: ISpecProp;
   maxValue?: ISpecProp;
 }
 
-function generateMessages(spec: IOnboardingTreemapSpec, visElement: Element): IOnboardingMessage[] {
-  const analyzing = defaultOnboardingStages.get(EDefaultOnboardingStages.ANALYZING) as IOnboardingStage;
-  const reading = defaultOnboardingStages.get(EDefaultOnboardingStages.READING) as IOnboardingStage;
-  const interacting = defaultOnboardingStages.get(EDefaultOnboardingStages.USING) as IOnboardingStage;
+function generateMessages(
+  spec: IOnboardingTreemapSpec,
+  visElement: Element
+): IOnboardingMessage[] {
+  const analyzing = defaultOnboardingStages.get(
+    EDefaultOnboardingStages.ANALYZING
+  ) as IOnboardingStage;
+  const reading = defaultOnboardingStages.get(
+    EDefaultOnboardingStages.READING
+  ) as IOnboardingStage;
+  const interacting = defaultOnboardingStages.get(
+    EDefaultOnboardingStages.USING
+  ) as IOnboardingStage;
 
   const messages = [
     {
       anchor: getAnchor(spec.chartTitle, visElement),
-      requires: ['chartTitle'],
+      requires: ["chartTitle"],
       text: `The chart shows the ${spec.chartTitle?.value}.`,
-      title: 'Reading the chart',
+      title: "Reading the chart",
       onboardingStage: reading,
       marker: {
-        id: "unique-marker-id-1"
-      }
+        id: "unique-marker-id-1",
+      },
     },
     {
       anchor: getAnchor(spec.desc, visElement),
-      requires: ['desc'],
+      requires: ["desc"],
       text: `The treemap visualization shows the breakdown of hierarchical data level by level.The size of each rectangle represents a quantitative value associated with each element in the hierarchy.`,
-      title: 'Reading the chart',
+      title: "Reading the chart",
       onboardingStage: reading,
       marker: {
-        id: "unique-marker-id-2"
-      }
+        id: "unique-marker-id-2",
+      },
     },
     {
       anchor: getAnchor(spec.subDesc, visElement),
-      requires: ['subDesc'],
+      requires: ["subDesc"],
       text: `The area covered by the whole treemap is subdivided recursively into sub-categories according to their quantitative values, level by level.`,
-      title: 'Reading the chart',
+      title: "Reading the chart",
       onboardingStage: reading,
       marker: {
-        id: "unique-marker-id-3"
-      }
+        id: "unique-marker-id-3",
+      },
     },
     {
       anchor: getAnchor(spec.otherDesc, visElement),
-      requires: ['otherDesc'],
+      requires: ["otherDesc"],
       text: `Items on the bottom level that belong to the same sub-category are visually represented by using the same color.`,
-      title: 'Reading the chart',
+      title: "Reading the chart",
       onboardingStage: reading,
       marker: {
-        id: "unique-marker-id-4"
-      }
+        id: "unique-marker-id-4",
+      },
     },
     {
       anchor: getAnchor(spec.gapDesc, visElement),
-      requires: ['gapDesc'],
+      requires: ["gapDesc"],
       text: `Items within a sub-category are represented by rectangles that are closely packed together with increasingly larger gaps to the neighboring categories.`,
-      title: 'Reading the chart',
+      title: "Reading the chart",
       onboardingStage: reading,
       marker: {
-        id: "unique-marker-id-5"
-      }
+        id: "unique-marker-id-5",
+      },
     },
 
     {
       anchor: getAnchor(spec.interactingDesc, visElement),
-      requires: ['interactingDesc'],
+      requires: ["interactingDesc"],
       text: `Hover over the rectangles to get the dedicated value of the sub-category and further information.`,
-      title: 'Interacting with the chart',
+      title: "Interacting with the chart",
       onboardingStage: interacting,
       marker: {
-        id: "unique-marker-id-6"
-      }
+        id: "unique-marker-id-6",
+      },
     },
 
     {
       anchor: getAnchor(spec.maxValueDesc, visElement),
-      requires: ['maxValueDesc', 'maxValue'],
+      requires: ["maxValueDesc", "maxValue"],
       text: `The largest rectangle holds the maximum value in the sub-category. In this sub-category ${spec.maxValue?.value} is the maximum value.`,
-      title: 'Analyzing the chart',
+      title: "Analyzing the chart",
       onboardingStage: analyzing,
       marker: {
-        id: "unique-marker-id-7"
-      }
+        id: "unique-marker-id-7",
+      },
     },
 
     {
       anchor: getAnchor(spec.minValueDesc, visElement),
-      requires: ['minValueDesc', 'minValue'],
+      requires: ["minValueDesc", "minValue"],
       text: ` The smallest rectangle holds the minimum value in the sub-category. In this sub-category ${spec.minValue?.value} is the minimum value.`,
-      title: 'Analyzing the chart',
+      title: "Analyzing the chart",
       onboardingStage: analyzing,
       marker: {
-        id: "unique-marker-id-8"
-      }
-    }
-    
+        id: "unique-marker-id-8",
+      },
+    },
   ];
 
+  if (spec.chartTitle?.value === undefined) {
+    messages.splice(0, 1);
+  }
+
   // Filter for messages where all template variables are available in the spec
-  return messages.filter((message) => message.requires.every((tplVars) => spec[tplVars]));
-};
+  return messages.filter((message) =>
+    message.requires.every((tplVars) => spec[tplVars])
+  );
+}
 
 export const treemap = {
-  generateMessages
+  generateMessages,
 };

--- a/packages/core/src/treemap.ts
+++ b/packages/core/src/treemap.ts
@@ -34,98 +34,174 @@ function generateMessages(
   const interacting = defaultOnboardingStages.get(
     EDefaultOnboardingStages.USING
   ) as IOnboardingStage;
-
-  const messages = [
-    {
-      anchor: getAnchor(spec.chartTitle, visElement),
-      requires: ["chartTitle"],
-      text: `The chart shows the ${spec.chartTitle?.value}.`,
-      title: "Reading the chart",
-      onboardingStage: reading,
-      marker: {
-        id: "unique-marker-id-1",
-      },
-    },
-    {
-      anchor: getAnchor(spec.desc, visElement),
-      requires: ["desc"],
-      text: `The treemap visualization shows the breakdown of hierarchical data level by level.The size of each rectangle represents a quantitative value associated with each element in the hierarchy.`,
-      title: "Reading the chart",
-      onboardingStage: reading,
-      marker: {
-        id: "unique-marker-id-2",
-      },
-    },
-    {
-      anchor: getAnchor(spec.subDesc, visElement),
-      requires: ["subDesc"],
-      text: `The area covered by the whole treemap is subdivided recursively into sub-categories according to their quantitative values, level by level.`,
-      title: "Reading the chart",
-      onboardingStage: reading,
-      marker: {
-        id: "unique-marker-id-3",
-      },
-    },
-    {
-      anchor: getAnchor(spec.otherDesc, visElement),
-      requires: ["otherDesc"],
-      text: `Items on the bottom level that belong to the same sub-category are visually represented by using the same color.`,
-      title: "Reading the chart",
-      onboardingStage: reading,
-      marker: {
-        id: "unique-marker-id-4",
-      },
-    },
-    {
-      anchor: getAnchor(spec.gapDesc, visElement),
-      requires: ["gapDesc"],
-      text: `Items within a sub-category are represented by rectangles that are closely packed together with increasingly larger gaps to the neighboring categories.`,
-      title: "Reading the chart",
-      onboardingStage: reading,
-      marker: {
-        id: "unique-marker-id-5",
-      },
-    },
-
-    {
-      anchor: getAnchor(spec.interactingDesc, visElement),
-      requires: ["interactingDesc"],
-      text: `Hover over the rectangles to get the dedicated value of the sub-category and further information.`,
-      title: "Interacting with the chart",
-      onboardingStage: interacting,
-      marker: {
-        id: "unique-marker-id-6",
-      },
-    },
-
-    {
-      anchor: getAnchor(spec.maxValueDesc, visElement),
-      requires: ["maxValueDesc", "maxValue"],
-      text: `The largest rectangle holds the maximum value in the sub-category. In this sub-category ${spec.maxValue?.value} is the maximum value.`,
-      title: "Analyzing the chart",
-      onboardingStage: analyzing,
-      marker: {
-        id: "unique-marker-id-7",
-      },
-    },
-
-    {
-      anchor: getAnchor(spec.minValueDesc, visElement),
-      requires: ["minValueDesc", "minValue"],
-      text: ` The smallest rectangle holds the minimum value in the sub-category. In this sub-category ${spec.minValue?.value} is the minimum value.`,
-      title: "Analyzing the chart",
-      onboardingStage: analyzing,
-      marker: {
-        id: "unique-marker-id-8",
-      },
-    },
-  ];
+  let messages: IOnboardingMessage[];
 
   if (spec.chartTitle?.value === undefined) {
-    messages.splice(0, 1);
+    messages = [
+      {
+        anchor: getAnchor(spec.desc, visElement),
+        requires: ["desc"],
+        text: `The treemap visualization shows the breakdown of hierarchical data level by level.The size of each rectangle represents a quantitative value associated with each element in the hierarchy.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-1",
+        },
+      },
+      {
+        anchor: getAnchor(spec.subDesc, visElement),
+        requires: ["subDesc"],
+        text: `The area covered by the whole treemap is subdivided recursively into sub-categories according to their quantitative values, level by level.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-2",
+        },
+      },
+      {
+        anchor: getAnchor(spec.otherDesc, visElement),
+        requires: ["otherDesc"],
+        text: `Items on the bottom level that belong to the same sub-category are visually represented by using the same color.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-3",
+        },
+      },
+      {
+        anchor: getAnchor(spec.gapDesc, visElement),
+        requires: ["gapDesc"],
+        text: `Items within a sub-category are represented by rectangles that are closely packed together with increasingly larger gaps to the neighboring categories.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-4",
+        },
+      },
+
+      {
+        anchor: getAnchor(spec.interactingDesc, visElement),
+        requires: ["interactingDesc"],
+        text: `Hover over the rectangles to get the dedicated value of the sub-category and further information.`,
+        title: "Interacting with the chart",
+        onboardingStage: interacting,
+        marker: {
+          id: "unique-marker-id-5",
+        },
+      },
+
+      {
+        anchor: getAnchor(spec.maxValueDesc, visElement),
+        requires: ["maxValueDesc", "maxValue"],
+        text: `The largest rectangle holds the maximum value in the sub-category. In this sub-category ${spec.maxValue?.value} is the maximum value.`,
+        title: "Analyzing the chart",
+        onboardingStage: analyzing,
+        marker: {
+          id: "unique-marker-id-6",
+        },
+      },
+
+      {
+        anchor: getAnchor(spec.minValueDesc, visElement),
+        requires: ["minValueDesc", "minValue"],
+        text: ` The smallest rectangle holds the minimum value in the sub-category. In this sub-category ${spec.minValue?.value} is the minimum value.`,
+        title: "Analyzing the chart",
+        onboardingStage: analyzing,
+        marker: {
+          id: "unique-marker-id-7",
+        },
+      },
+    ];
+  } else {
+    messages = [
+      {
+        anchor: getAnchor(spec.chartTitle, visElement),
+        requires: ["chartTitle"],
+        text: `The chart shows the ${spec.chartTitle?.value}.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-1",
+        },
+      },
+      {
+        anchor: getAnchor(spec.desc, visElement),
+        requires: ["desc"],
+        text: `The treemap visualization shows the breakdown of hierarchical data level by level.The size of each rectangle represents a quantitative value associated with each element in the hierarchy.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-2",
+        },
+      },
+      {
+        anchor: getAnchor(spec.subDesc, visElement),
+        requires: ["subDesc"],
+        text: `The area covered by the whole treemap is subdivided recursively into sub-categories according to their quantitative values, level by level.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-3",
+        },
+      },
+      {
+        anchor: getAnchor(spec.otherDesc, visElement),
+        requires: ["otherDesc"],
+        text: `Items on the bottom level that belong to the same sub-category are visually represented by using the same color.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-4",
+        },
+      },
+      {
+        anchor: getAnchor(spec.gapDesc, visElement),
+        requires: ["gapDesc"],
+        text: `Items within a sub-category are represented by rectangles that are closely packed together with increasingly larger gaps to the neighboring categories.`,
+        title: "Reading the chart",
+        onboardingStage: reading,
+        marker: {
+          id: "unique-marker-id-5",
+        },
+      },
+
+      {
+        anchor: getAnchor(spec.interactingDesc, visElement),
+        requires: ["interactingDesc"],
+        text: `Hover over the rectangles to get the dedicated value of the sub-category and further information.`,
+        title: "Interacting with the chart",
+        onboardingStage: interacting,
+        marker: {
+          id: "unique-marker-id-6",
+        },
+      },
+
+      {
+        anchor: getAnchor(spec.maxValueDesc, visElement),
+        requires: ["maxValueDesc", "maxValue"],
+        text: `The largest rectangle holds the maximum value in the sub-category. In this sub-category ${spec.maxValue?.value} is the maximum value.`,
+        title: "Analyzing the chart",
+        onboardingStage: analyzing,
+        marker: {
+          id: "unique-marker-id-7",
+        },
+      },
+
+      {
+        anchor: getAnchor(spec.minValueDesc, visElement),
+        requires: ["minValueDesc", "minValue"],
+        text: ` The smallest rectangle holds the minimum value in the sub-category. In this sub-category ${spec.minValue?.value} is the minimum value.`,
+        title: "Analyzing the chart",
+        onboardingStage: analyzing,
+        marker: {
+          id: "unique-marker-id-8",
+        },
+      },
+    ];
   }
 
   // Filter for messages where all template variables are available in the spec
+
   return messages.filter((message) =>
     message.requires.every((tplVars) => spec[tplVars])
   );

--- a/packages/echarts-demo/src/scatterplot.js
+++ b/packages/echarts-demo/src/scatterplot.js
@@ -1,54 +1,62 @@
 import * as echarts from 'echarts';
-import { generateBasicAnnotations, ahoi, EVisualizationType } from '@visahoi/echarts';
-import debounce from "lodash.debounce";
+import {
+  generateBasicAnnotations,
+  ahoi,
+  EVisualizationType,
+} from '@visahoi/echarts';
+import debounce from 'lodash.debounce';
 
 let chart = null;
 let showOnboarding = false;
 let onboardingUI = null;
 
 const debouncedResize = debounce((event) => {
-  onboardingUI?.updateOnboarding(getAhoiConfig())
+  onboardingUI?.updateOnboarding(getAhoiConfig());
 }, 250);
 
 function render() {
-  fetch("../data/cars.json").then(response => response.json()).then(data => {
-  chart = createPlot(processData(data));
-  window.addEventListener("resize", debouncedResize);
-
-  });
+  fetch('../data/cars.json')
+    .then((response) => response.json())
+    .then((data) => {
+      chart = createPlot(processData(data));
+      window.addEventListener('resize', debouncedResize);
+    });
 }
 
 function processData(allRows) {
-  const values = Object.values(allRows).map((row => [row.Horsepower, row.Miles_per_Gallon]))
+  const values = Object.values(allRows).map((row) => [
+    row.Horsepower,
+    row.Miles_per_Gallon,
+  ]);
   return values;
 }
 
 function createPlot(values) {
   const options = {
     title: {
-      text: "Some title of cars or something",
-      left: "center"
+      text: 'Some title of cars or something',
+      left: 'center',
     },
     tooltip: {},
     xAxis: {
-      type: "value",
-      name: "Horsepower",
-      nameLocation: "middle",
+      type: 'value',
+      name: 'Horsepower',
+      nameLocation: 'middle',
       nameGap: 30,
     },
     yAxis: {
-      type: "value",
-      name: "Miles per Gallon",
-      nameLocation: "middle",
-      nameGap: 35
+      type: 'value',
+      name: 'Miles per Gallon',
+      nameLocation: 'middle',
+      nameGap: 35,
     },
     series: [
       {
         data: values,
-        type: "scatter",
-        symbolSize: 4
-      }
-    ]
+        type: 'scatter',
+        symbolSize: 4,
+      },
+    ],
   };
 
   chart.setOption(options);
@@ -56,37 +64,45 @@ function createPlot(values) {
 }
 
 const getAhoiConfig = () => {
-  const defaultOnboardingMessages = generateBasicAnnotations(EVisualizationType.SCATTERPLOT, chart);
+  const defaultOnboardingMessages = generateBasicAnnotations(
+    EVisualizationType.SCATTERPLOT,
+    chart,
+  );
   const extendedOnboardingMessages = defaultOnboardingMessages.map((d) => ({
     ...d,
-    text: "test123"
+    text: 'test123',
   }));
   const ahoiConfig = {
     onboardingMessages: defaultOnboardingMessages,
-  }
+  };
   return ahoiConfig;
-}
+};
 
-const registerEventListener = () => { 
-  console.log(showOnboarding)   
-  const helpIcon = document.getElementById("show-onboarding");
-  if(!helpIcon) { return; }
+const registerEventListener = () => {
+  const helpIcon = document.getElementById('show-onboarding');
+  if (!helpIcon) {
+    return;
+  }
   helpIcon.addEventListener('click', async () => {
     showOnboarding = !showOnboarding;
-    if(showOnboarding) {
-      onboardingUI = await ahoi(EVisualizationType.SCATTERPLOT, chart, getAhoiConfig());
+    if (showOnboarding) {
+      onboardingUI = await ahoi(
+        EVisualizationType.SCATTERPLOT,
+        chart,
+        getAhoiConfig(),
+      );
     } else {
       onboardingUI?.removeOnboarding();
-    }    
-  })
-}
+    }
+  });
+};
 
 const createChart = (renderer = 'svg') => {
-  const vis = document.getElementById("vis");
-  chart = echarts.init(vis, null, {renderer});
-  window.addEventListener("resize", () => chart.resize());
+  const vis = document.getElementById('vis');
+  chart = echarts.init(vis, null, { renderer });
+  window.addEventListener('resize', () => chart.resize());
   registerEventListener();
   render();
-}
+};
 
 export default createChart;

--- a/packages/echarts/src/bar-chart.ts
+++ b/packages/echarts/src/bar-chart.ts
@@ -20,29 +20,35 @@ function extractOnboardingSpec(chart, coords): IOnboardingBarChartSpec {
   const mainAxis = getMainAxis(options.xAxis[0].type, options.yAxis[0].type);
   return {
     chartTitle: {
-      value: options.title[0].text,
+      value: options?.title[0]?.text,
       anchor: {
         findDomNodeByValue: true,
-        offset: {left: -20, top: 10}
-      }
+        offset: { left: -20, top: 10 },
+      },
     },
     yMin: {
       value: data._store._rawExtent[1][0],
       anchor: {
-        coords: {x: dataCoords[1].x + dataCoords[1].width/2, y: dataCoords[1].y + dataCoords[1].height}
-      }
+        coords: {
+          x: dataCoords[1].x + dataCoords[1].width / 2,
+          y: dataCoords[1].y + dataCoords[1].height,
+        },
+      },
     },
     type: {
       value: data.hostModel.option.type,
       anchor: {
-        coords: dataCoords[8]
-      }
+        coords: dataCoords[8],
+      },
     },
     yMax: {
       value: data._store._rawExtent[1][1],
       anchor: {
-        coords: {x: dataCoords[6].x + dataCoords[6].width/2, y: dataCoords[6].y + dataCoords[6].height}
-      }
+        coords: {
+          x: dataCoords[6].x + dataCoords[6].width / 2,
+          y: dataCoords[6].y + dataCoords[6].height,
+        },
+      },
     },
     // orientation: {
     //   value: mainAxis && (mainAxis === "x" ? "horizontal" : "vertical")
@@ -51,10 +57,10 @@ function extractOnboardingSpec(chart, coords): IOnboardingBarChartSpec {
     //   value: mainAxis && (mainAxis === "x" ? "horizontal" : "vertical")
     // },
     xAxisOrientation: {
-      value: mainAxis && (mainAxis === "x" ? "horizontal" : "vertical")
+      value: mainAxis && (mainAxis === "x" ? "horizontal" : "vertical"),
     },
     barLength: {
-      value: mainAxis && (mainAxis === "x" ? "height" : "width")
+      value: mainAxis && (mainAxis === "x" ? "height" : "width"),
     },
     // xMin: {
     //   value: data._rawExtent.x[0]
@@ -66,20 +72,28 @@ function extractOnboardingSpec(chart, coords): IOnboardingBarChartSpec {
       value: options.xAxis[0].name,
       anchor: {
         findDomNodeByValue: true,
-        offset: {left: -20, top: 5}
-      }
+        offset: { left: -20, top: 5 },
+      },
     },
     yAxisTitle: {
       value: options.yAxis[0].name,
       anchor: {
         findDomNodeByValue: true,
-        offset: {top: -20}
-      }
-    }
+        offset: { top: -20 },
+      },
+    },
   };
 }
 
-export function barChartFactory(chart, coords, visElementId: Element): IOnboardingMessage[] {
+export function barChartFactory(
+  chart,
+  coords,
+  visElementId: Element
+): IOnboardingMessage[] {
   const onbordingSpec = extractOnboardingSpec(chart, coords);
-  return generateMessages(EVisualizationType.BAR_CHART, onbordingSpec, visElementId);
+  return generateMessages(
+    EVisualizationType.BAR_CHART,
+    onbordingSpec,
+    visElementId
+  );
 }

--- a/packages/echarts/src/change-matrix.ts
+++ b/packages/echarts/src/change-matrix.ts
@@ -7,16 +7,18 @@ import {
 
 function extractOnboardingSpec(chart, coords): IOnboardingChangeMatrixSpec {
   // const dataCoords = chart._chartsViews[0]._data._itemLayouts;
-  const legendPosition = chart._componentsMap["_ec_\u0000series\u00000\u00000_visualMap.continuous"].group.position;
-  const legendTitle = {x: legendPosition[0], y: legendPosition[1] + 20};
+  const legendPosition =
+    chart._componentsMap["_ec_\u0000series\u00000\u00000_visualMap.continuous"]
+      .group.position;
+  const legendTitle = { x: legendPosition[0], y: legendPosition[1] + 20 };
   const options = chart._model.option;
   return {
     chartTitle: {
-      value: options.title[0].text,
+      value: options?.title[0]?.text,
       anchor: {
         findDomNodeByValue: true,
-        offset: {left: -20, top: 10}
-      }
+        offset: { left: -20, top: 10 },
+      },
     },
     // type: {
     //   value: "cell",
@@ -27,34 +29,42 @@ function extractOnboardingSpec(chart, coords): IOnboardingChangeMatrixSpec {
     legendTitle: {
       value: options.visualMap[0].text[1],
       anchor: {
-        coords: legendTitle
-      }
+        coords: legendTitle,
+      },
     },
     xAxis: {
       value: options.xAxis[0].name,
       anchor: {
         findDomNodeByValue: true,
-        offset: {left: -20}
-      }
+        offset: { left: -20 },
+      },
     },
     yAxis: {
       value: options.yAxis[0].name,
       anchor: {
         findDomNodeByValue: true,
-      }
+      },
     },
     type: {
       value: "area",
       domNodeValue: options.yAxis[0].data[2],
       anchor: {
         findDomNodeByValue: true,
-        offset: {top: -10, left: 60}
-      }
+        offset: { top: -10, left: 60 },
+      },
     },
-  }
+  };
 }
 
-export function changeMatrixFactory(chart, coords, visElementId: Element): IOnboardingMessage[] {
+export function changeMatrixFactory(
+  chart,
+  coords,
+  visElementId: Element
+): IOnboardingMessage[] {
   const onbordingSpec = extractOnboardingSpec(chart, coords);
-  return generateMessages(EVisualizationType.CHANGE_MATRIX, onbordingSpec, visElementId);
+  return generateMessages(
+    EVisualizationType.CHANGE_MATRIX,
+    onbordingSpec,
+    visElementId
+  );
 }

--- a/packages/echarts/src/horizon-graph.ts
+++ b/packages/echarts/src/horizon-graph.ts
@@ -5,56 +5,64 @@ import {
   generateMessages,
 } from "@visahoi/core";
 
-const getMinMax= (values) => {
+const getMinMax = (values) => {
   const unified: number[] = new Array(values[0].data.length).fill(0);
   values.forEach((v, i) => {
     v.data.forEach((val, index) => {
-      if(i === 2) {
-        unified[index] -= val
+      if (i === 2) {
+        unified[index] -= val;
+      } else {
+        unified[index] += val;
       }
-      else {
-        unified[index] += val
-      }
-    })
-  })
+    });
+  });
   const min = Math.min(...unified);
   const max = Math.max(...unified);
-  return [min, max]
-}
+  return [min, max];
+};
 
 function extractOnboardingSpec(chart, coords): IOnboardingHorizonGraphSpec {
-  const xAxis = [chart._chartsViews[0]._points[6], chart._chartsViews[0]._points[7]];
-  const positiveColor = [chart._chartsViews[1]._points[10], chart._chartsViews[1]._points[11]];
-  const negativeColor = [chart._chartsViews[2]._points[0], chart._chartsViews[2]._points[1]];
+  const xAxis = [
+    chart._chartsViews[0]._points[6],
+    chart._chartsViews[0]._points[7],
+  ];
+  const positiveColor = [
+    chart._chartsViews[1]._points[10],
+    chart._chartsViews[1]._points[11],
+  ];
+  const negativeColor = [
+    chart._chartsViews[2]._points[0],
+    chart._chartsViews[2]._points[1],
+  ];
   const options = chart._model.option;
   const [min, max] = getMinMax(chart._model.option.series);
   return {
     chartTitle: {
-      value: options.title[0].text,
+      value: options?.title[0]?.text,
       anchor: {
         findDomNodeByValue: true,
-        offset: {left: -20, top: 10}
-      }
+        offset: { left: -20, top: 10 },
+      },
     },
     xAxis: {
       value: options.xAxis[0].name,
       anchor: {
-        coords: {x: xAxis[0], y: xAxis[1]}
-      }
+        coords: { x: xAxis[0], y: xAxis[1] },
+      },
     },
     yAxis: {
       value: options.yAxis[0].name,
       anchor: {
         findDomNodeByValue: true,
-      }
+      },
     },
     yMin: {
       value: min,
       anchor: {
         coords: {
           x: chart._chartsViews[2]._points[2],
-          y: chart._chartsViews[2]._points[3]
-        }
+          y: chart._chartsViews[2]._points[3],
+        },
       },
     },
     yMax: {
@@ -62,33 +70,44 @@ function extractOnboardingSpec(chart, coords): IOnboardingHorizonGraphSpec {
       anchor: {
         coords: {
           x: chart._chartsViews[1]._points[12],
-          y: chart._chartsViews[1]._points[13]
-        }
+          y: chart._chartsViews[1]._points[13],
+        },
       },
     },
     positiveColor: {
       value: chart._chartsViews[0].__model.option.color,
       anchor: {
-        coords: {x: positiveColor[0], y: positiveColor[1]}
-      }
+        coords: { x: positiveColor[0], y: positiveColor[1] },
+      },
     },
     negativeColor: {
       value: chart._chartsViews[2].__model.option.color,
       anchor: {
-        coords: {x: negativeColor[0], y: negativeColor[1]},
-        offset: {left: 20}
-      }
+        coords: { x: negativeColor[0], y: negativeColor[1] },
+        offset: { left: 20 },
+      },
     },
     type: {
       value: "area",
       anchor: {
-        coords: {x: chart._chartsViews[0]._points[16], y: chart._chartsViews[0]._points[6]}
-      }
-    }
+        coords: {
+          x: chart._chartsViews[0]._points[16],
+          y: chart._chartsViews[0]._points[6],
+        },
+      },
+    },
   };
 }
 
-export function horizonGraphFactory(chart, coords, visElementId: Element): IOnboardingMessage[] {
+export function horizonGraphFactory(
+  chart,
+  coords,
+  visElementId: Element
+): IOnboardingMessage[] {
   const onbordingSpec = extractOnboardingSpec(chart, coords);
-  return generateMessages(EVisualizationType.HORIZON_GRAPH, onbordingSpec, visElementId);
+  return generateMessages(
+    EVisualizationType.HORIZON_GRAPH,
+    onbordingSpec,
+    visElementId
+  );
 }

--- a/packages/echarts/src/scatterplot.ts
+++ b/packages/echarts/src/scatterplot.ts
@@ -1,60 +1,70 @@
-import { EVisualizationType, IOnboardingMessage, generateMessages } from "@visahoi/core";
+import {
+  EVisualizationType,
+  IOnboardingMessage,
+  generateMessages,
+} from "@visahoi/core";
 import { IOnboardingScatterplotSpec } from "@visahoi/core/src/scatterplot";
 
-  function extractOnboardingSpec(chart, coords): IOnboardingScatterplotSpec {
-    const dataCoords = chart._chartsViews[0]._symbolDraw._data._itemLayouts;
-    const data = chart._chartsViews[0]._symbolDraw._data;
-    const options = chart._model.option;
+function extractOnboardingSpec(chart, coords): IOnboardingScatterplotSpec {
+  const dataCoords = chart._chartsViews[0]._symbolDraw._data._itemLayouts;
+  const data = chart._chartsViews[0]._symbolDraw._data;
+  const options = chart._model.option;
 
-    const points = dataCoords.filter(
-        (point) => point[0] && point[1]
-      );
-    const xVals = [...points.map((point) => point[0])];
-    const yVals = [...points.map((point) => point[1])];
-    let maxX = Math.max(...xVals);
-    const maxXIndex = xVals.indexOf(maxX);
-    const maxY = yVals[maxXIndex] + chart._dom.offsetTop;
-    maxX += + chart._dom.offsetLeft;
+  const points = dataCoords.filter((point) => point[0] && point[1]);
+  const xVals = [...points.map((point) => point[0])];
+  const yVals = [...points.map((point) => point[1])];
+  let maxX = Math.max(...xVals);
+  const maxXIndex = xVals.indexOf(maxX);
+  const maxY = yVals[maxXIndex] + chart._dom.offsetTop;
+  maxX += +chart._dom.offsetLeft;
 
-    return {
-      chartTitle: {
-        value: options.title[0].text,
-        anchor: {
-          findDomNodeByValue: true,
-          offset: {left: -20, top: 10}
-        }
+  return {
+    chartTitle: {
+      value: options?.title[0]?.text,
+      anchor: {
+        findDomNodeByValue: true,
+        offset: { left: -20, top: 10 },
       },
-      type: {
-        value: "scatter",
-        anchor: {
-          coords: {x: dataCoords[16][0], y: dataCoords[16][1]}
-        }
+    },
+    type: {
+      value: "scatter",
+      anchor: {
+        coords: { x: dataCoords[16][0], y: dataCoords[16][1] },
       },
-      yAxisTitle: {
-        value: options.yAxis[0].name,
-        anchor: {
-          findDomNodeByValue: true,
-          offset: {top: -20, left: 10}
-        }
+    },
+    yAxisTitle: {
+      value: options.yAxis[0].name,
+      anchor: {
+        findDomNodeByValue: true,
+        offset: { top: -20, left: 10 },
       },
-      xAxisTitle: {
-        value: options.xAxis[0].name,
-        anchor: {
-          findDomNodeByValue: true,
-          offset: {left: -20, top: 10}
-        }
+    },
+    xAxisTitle: {
+      value: options.xAxis[0].name,
+      anchor: {
+        findDomNodeByValue: true,
+        offset: { left: -20, top: 10 },
       },
-      maxValue: {
-          value: maxX,
-          anchor: {
-            coords: {x: maxX, y: maxY},
-            offset: {left: 25}
-          }
-      }
-    };
-  }
+    },
+    maxValue: {
+      value: maxX,
+      anchor: {
+        coords: { x: maxX, y: maxY },
+        offset: { left: 25 },
+      },
+    },
+  };
+}
 
-  export function scatterplotFactory(chart, coords, visElementId: Element): IOnboardingMessage[] {
-    const onbordingSpec = extractOnboardingSpec(chart, coords);
-    return generateMessages(EVisualizationType.SCATTERPLOT, onbordingSpec, visElementId);
-  }
+export function scatterplotFactory(
+  chart,
+  coords,
+  visElementId: Element
+): IOnboardingMessage[] {
+  const onbordingSpec = extractOnboardingSpec(chart, coords);
+  return generateMessages(
+    EVisualizationType.SCATTERPLOT,
+    onbordingSpec,
+    visElementId
+  );
+}

--- a/packages/plotly-demo/src/bar-chart.js
+++ b/packages/plotly-demo/src/bar-chart.js
@@ -1,6 +1,10 @@
-import Plotly from 'plotly.js-dist'
-import { generateBasicAnnotations, ahoi, EVisualizationType } from '@visahoi/plotly';
-import debounce from "lodash.debounce";
+import Plotly from 'plotly.js-dist';
+import {
+  generateBasicAnnotations,
+  ahoi,
+  EVisualizationType,
+} from '@visahoi/plotly';
+import debounce from 'lodash.debounce';
 import { importCsv } from './util';
 
 let chart = null;
@@ -8,14 +12,14 @@ let showOnboarding = false;
 let onboardingUI = null;
 
 const debouncedResize = debounce((event) => {
-  onboardingUI?.updateOnboarding(getAhoiConfig())
+  onboardingUI?.updateOnboarding(getAhoiConfig());
 }, 250);
 
 async function render() {
-  const data = await importCsv("./data/oslo-2018.csv");
-  const {x, y} = processData(data);
+  const data = await importCsv('./data/oslo-2018.csv');
+  const { x, y } = processData(data);
   chart = await makePlotly(x, y);
-  window.addEventListener("resize", debouncedResize);
+  window.addEventListener('resize', debouncedResize);
 }
 
 function processData(allRows) {
@@ -26,72 +30,81 @@ function processData(allRows) {
     x.push(`${row.year}-${row.month}`);
     y.push(row.temp);
   }
-  return {x, y};
+  return { x, y };
 }
 
 function makePlotly(x, y) {
-  document.getElementById("plot");
+  document.getElementById('plot');
   const traces = [
     {
-      type: "bar",
+      type: 'bar',
       x: x, // ['2018-01', '2018-01', ...]
       y: y, // [1.9, 0.1, ...]
       transforms: [
         {
-          type: "aggregate",
+          type: 'aggregate',
           groups: x,
-          aggregations: [{ target: "y", func: "avg", enabled: true }]
-        }
+          aggregations: [{ target: 'y', func: 'avg', enabled: true }],
+        },
       ],
       marker: {
-        color: "lightgrey"
-      }
-    }
+        color: 'lightgrey',
+      },
+    },
   ];
 
   const layout = {
-    title: "Average temperature in Oslo, Norway in 2018",
+    title: 'Average temperature in Oslo, Norway in 2018',
     xaxis: {
-      title: "Month",
-      tickformat: "%m",
-      nticks: 12
+      title: 'Month',
+      tickformat: '%m',
+      nticks: 12,
     },
     yaxis: {
-      title: "Average temperature in °C"
-    }
+      title: 'Average temperature in °C',
+    },
   };
 
   const config = {
-    responsive: true
+    responsive: true,
   };
 
-  return Plotly.newPlot("vis", traces, layout, config);
+  return Plotly.newPlot('vis', traces, layout, config);
 }
 
 const getAhoiConfig = () => {
-  const defaultOnboardingMessages = generateBasicAnnotations(EVisualizationType.BAR_CHART, chart);
+  const defaultOnboardingMessages = generateBasicAnnotations(
+    EVisualizationType.BAR_CHART,
+    chart,
+  );
   const extendedOnboardingMessages = defaultOnboardingMessages.map((d) => ({
     ...d,
-    text: "test123"
+    text: 'test123',
   }));
   const ahoiConfig = {
     onboardingMessages: defaultOnboardingMessages,
-  }
+  };
   return ahoiConfig;
-}
+};
 
-const registerEventListener = () => {  
-  const helpIcon = document.getElementById("show-onboarding");
-  if(!helpIcon) { return; }
+const registerEventListener = () => {
+  const helpIcon = document.getElementById('show-onboarding');
+  if (!helpIcon) {
+    return;
+  }
   helpIcon.addEventListener('click', async () => {
     showOnboarding = !showOnboarding;
-    if(showOnboarding) {
-      onboardingUI = await ahoi(EVisualizationType.BAR_CHART, chart, getAhoiConfig());
+    if (showOnboarding) {
+      onboardingUI = await ahoi(
+        EVisualizationType.BAR_CHART,
+        chart,
+        getAhoiConfig(),
+      );
     } else {
       onboardingUI?.removeOnboarding();
-    }    
-  })
-}
+    }
+  });
+};
 
 registerEventListener();
 render();

--- a/packages/plotly-demo/src/change-matrix.js
+++ b/packages/plotly-demo/src/change-matrix.js
@@ -1,25 +1,28 @@
-import Plotly from 'plotly.js-dist'
-import { generateBasicAnnotations, ahoi, EVisualizationType} from '@visahoi/plotly';
-import debounce from "lodash.debounce";
+import Plotly from 'plotly.js-dist';
+import {
+  generateBasicAnnotations,
+  ahoi,
+  EVisualizationType,
+} from '@visahoi/plotly';
+import debounce from 'lodash.debounce';
 
 let chart = null;
 let showOnboarding = false;
 let onboardingUI = null;
 
 const debouncedResize = debounce((event) => {
-  onboardingUI?.updateOnboarding(getAhoiConfig())
+  onboardingUI?.updateOnboarding(getAhoiConfig());
 }, 250);
 
 async function render() {
   const response = await fetch('./data/matrix.json');
   const data = await response.json();
-  const {x, y, z} = processData(data);
-  chart = await makePlotly(x, y, z)
-  window.addEventListener("resize", debouncedResize);
+  const { x, y, z } = processData(data);
+  chart = await makePlotly(x, y, z);
+  window.addEventListener('resize', debouncedResize);
 }
 
 function processData(allRows) {
-
   const nestedDataByCity = new Map();
 
   allRows.forEach((row) => {
@@ -32,75 +35,88 @@ function processData(allRows) {
 
   const x = new Set(allRows.map((row) => row.b));
   const y = [...nestedDataByCity.keys()];
-  const z = [...nestedDataByCity.values()].map(value => [...value.map(v => v.c)]);
+  const z = [...nestedDataByCity.values()].map((value) => [
+    ...value.map((v) => v.c),
+  ]);
 
-  return {x, y, z};
+  return { x, y, z };
 }
 
-
 function makePlotly(x, y, z) {
-  document.getElementById("plot");
+  document.getElementById('plot');
   const traces = [
     {
-      type: "heatmap",
+      type: 'heatmap',
       x, // date
       y, // city
       z, // values,
       zmin: -9,
       zmax: 9,
-      colorscale: [[0, "#4682b4"], [0.5, "#FDFDFD"], [1, "#D2B48C"]],
+      colorscale: [
+        [0, '#4682b4'],
+        [0.5, '#FDFDFD'],
+        [1, '#D2B48C'],
+      ],
       //showscale: false.
       colorbar: {
         title: {
-          text: "Value Change"
-        }
-      }
-    }
+          text: 'Value Change',
+        },
+      },
+    },
   ];
 
   const layout = {
-    title: "Average temperature change in °C between 1990 and 1991",
+    title: 'Average temperature change in °C between 1990 and 1991',
     xaxis: {
-      title: "Month"
+      title: 'Month',
     },
     yaxis: {
-      title: "City"
-    }
+      title: 'City',
+    },
   };
 
   const config = {
-    responsive: true
+    responsive: true,
   };
 
-  return Plotly.newPlot("vis", traces, layout, config);
+  return Plotly.newPlot('vis', traces, layout, config);
 }
 
 const getAhoiConfig = () => {
-  const defaultOnboardingMessages = generateBasicAnnotations(EVisualizationType.CHANGE_MATRIX, chart);
+  const defaultOnboardingMessages = generateBasicAnnotations(
+    EVisualizationType.CHANGE_MATRIX,
+    chart,
+  );
   const extendedOnboardingMessages = defaultOnboardingMessages.map((d) => ({
     ...d,
-    text: "test123"
+    text: 'test123',
   }));
   const ahoiConfig = {
     onboardingMessages: defaultOnboardingMessages,
-  }
+  };
   return ahoiConfig;
-}
+};
 
 const registerEventListener = () => {
   showOnboarding = !showOnboarding;
-  const helpIcon = document.getElementById("show-onboarding");
-  if(!helpIcon) { return; }
+  const helpIcon = document.getElementById('show-onboarding');
+  if (!helpIcon) {
+    return;
+  }
   helpIcon.addEventListener('click', async () => {
     showOnboarding = !showOnboarding;
-    if(showOnboarding) {
-
-      onboardingUI = await ahoi(EVisualizationType.CHANGE_MATRIX, chart, getAhoiConfig());
+    if (showOnboarding) {
+      onboardingUI = await ahoi(
+        EVisualizationType.CHANGE_MATRIX,
+        chart,
+        getAhoiConfig(),
+      );
     } else {
       onboardingUI?.removeOnboarding();
-    }    
-  })
-}
+    }
+  });
+};
 
 registerEventListener();
 render();

--- a/packages/plotly-demo/src/horizon-graph.js
+++ b/packages/plotly-demo/src/horizon-graph.js
@@ -1,6 +1,13 @@
-import Plotly from 'plotly.js-dist'
-import { generateBasicAnnotations, ahoi, EVisualizationType, createBasicOnboardingStage, getOnboardingStages, createBasicOnboardingMessage } from '@visahoi/plotly';
-import debounce from "lodash.debounce";
+import Plotly from 'plotly.js-dist';
+import {
+  generateBasicAnnotations,
+  ahoi,
+  EVisualizationType,
+  createBasicOnboardingStage,
+  getOnboardingStages,
+  createBasicOnboardingMessage,
+} from '@visahoi/plotly';
+import debounce from 'lodash.debounce';
 import { importCsv } from './util';
 
 let chart = null;
@@ -8,14 +15,14 @@ let showOnboarding = false;
 let onboardingUI = null;
 
 const debouncedResize = debounce((event) => {
-  onboardingUI?.updateOnboarding(getAhoiConfig())
+  onboardingUI?.updateOnboarding(getAhoiConfig());
 }, 250);
 
 async function render() {
-  const data = await importCsv("./data/oslo-2018.csv");
+  const data = await importCsv('./data/oslo-2018.csv');
   const { x, y } = processData(data);
   chart = await makePlotly(x, y);
-  window.addEventListener("resize", debouncedResize);
+  window.addEventListener('resize', debouncedResize);
 }
 
 function processData(allRows) {
@@ -40,7 +47,7 @@ function processData(allRows) {
     }
   }
 
-  const averagedYValues = y.map(tempArray => {
+  const averagedYValues = y.map((tempArray) => {
     const sum = tempArray.reduce((a, b) => {
       return a + b;
     }, 0);
@@ -50,137 +57,152 @@ function processData(allRows) {
 }
 
 function makePlotly(x, y) {
-  document.getElementById("plot");
+  document.getElementById('plot');
   const traces = [
     {
-      name: "Between 0 and 15 °C",
-      type: "scatter",
+      name: 'Between 0 and 15 °C',
+      type: 'scatter',
       x: x, // ['2018-01', '2018-01', ...]
-      y: y.map(item => (item < 0 ? 0 : item > 15 ? 15 : item)), // [1.9, 0.1, ...]
+      y: y.map((item) => (item < 0 ? 0 : item > 15 ? 15 : item)), // [1.9, 0.1, ...]
       // y: y.map(item => (item < 0 ? (item * -1) : item)), // [1.9, 0.1, ...]
-      fill: "tozeroy",
-      fillcolor: "rgba(161, 215, 106, 0.6)", // #a1d76a + 0.6 opacity
-      mode: "none", // no extra line + points for values
+      fill: 'tozeroy',
+      fillcolor: 'rgba(161, 215, 106, 0.6)', // #a1d76a + 0.6 opacity
+      mode: 'none', // no extra line + points for values
       line: {
-        shape: "spline",
-        smoothing: 0.25
+        shape: 'spline',
+        smoothing: 0.25,
       },
-      hovertemplate: "%{y:.2f}"
+      hovertemplate: '%{y:.2f}',
     },
     {
-      name: "More than 15 °C",
-      type: "scatter",
+      name: 'More than 15 °C',
+      type: 'scatter',
       x: x, // ['2018-01', '2018-01', ...]
-      y: y.map(item => (item > 15 ? item - 15 : 0)), // [1.9, 0.1, ...]
-      fill: "tozeroy",
-      fillcolor: "rgba(161, 215, 106, 1)", // #a1d76a + 0.6 opacity
-      mode: "none", // no extra line + no points for values,
+      y: y.map((item) => (item > 15 ? item - 15 : 0)), // [1.9, 0.1, ...]
+      fill: 'tozeroy',
+      fillcolor: 'rgba(161, 215, 106, 1)', // #a1d76a + 0.6 opacity
+      mode: 'none', // no extra line + no points for values,
       line: {
-        shape: "spline",
-        smoothing: 0.25
+        shape: 'spline',
+        smoothing: 0.25,
       },
-      hovertemplate: "%{y:.2f}"
+      hovertemplate: '%{y:.2f}',
     },
     {
-      name: "Less than 0 °C",
-      type: "scatter",
+      name: 'Less than 0 °C',
+      type: 'scatter',
       x: x, // ['2018-01', '2018-01', ...]
-      y: y.map(item => (item < 0 ? item * -1 : 0)), // [1.9, 0.1, ...]
-      fill: "tozeroy",
-      fillcolor: "rgba(5, 113, 176, 1)", // #0571b0 + 1 opacity
-      mode: "none", // no extra line + no points for values
+      y: y.map((item) => (item < 0 ? item * -1 : 0)), // [1.9, 0.1, ...]
+      fill: 'tozeroy',
+      fillcolor: 'rgba(5, 113, 176, 1)', // #0571b0 + 1 opacity
+      mode: 'none', // no extra line + no points for values
       line: {
-        shape: "spline",
-        smoothing: 0.25
+        shape: 'spline',
+        smoothing: 0.25,
       },
       //hoverinfo: "x+y"
-      hovertemplate: "-%{y:.2f}"
-    }
+      hovertemplate: '-%{y:.2f}',
+    },
   ];
 
   const layout = {
-    title: "Average temperature in Oslo, Norway in 2018",
+    title: 'Average temperature in Oslo, Norway in 2018',
     xaxis: {
-      title: "Month",
-      tickformat: "%m",
-      nticks: 12
+      title: 'Month',
+      tickformat: '%m',
+      nticks: 12,
     },
     yaxis: {
-      title: "Average temperature in °C"
+      title: 'Average temperature in °C',
     },
-    showlegend: false
+    showlegend: false,
   };
 
   const config = {
-    responsive: true
+    responsive: true,
   };
 
-  return Plotly.newPlot("vis", traces, layout, config);
+  return Plotly.newPlot('vis', traces, layout, config);
 }
 
 const getAhoiConfig = () => {
-  const defaultOnboardingMessages = generateBasicAnnotations(EVisualizationType.HORIZON_GRAPH, chart);
+  const defaultOnboardingMessages = generateBasicAnnotations(
+    EVisualizationType.HORIZON_GRAPH,
+    chart,
+  );
   const newOnboardingStage = createBasicOnboardingStage({
-    title: "New stage",
-    iconClass: "fas fa-flask",
-    backgroundColor: "tomato",
+    title: 'New stage',
+    iconClass: 'fas fa-flask',
+    backgroundColor: 'tomato',
   });
   const extendedOnboardingMessages = defaultOnboardingMessages.map((d) => ({
     ...d,
-    text: "test123"
+    text: 'test123',
   }));
   defaultOnboardingMessages[0].onboardingStage = newOnboardingStage;
-  defaultOnboardingMessages[0].title = "New stage";
-  defaultOnboardingMessages.push(createBasicOnboardingMessage({
-    text: "This is the newly added onboarding message for the horizon chart. It's absolutely positioned.",
-    title: "Absolutely positioned message",
-    onboardingStage: newOnboardingStage,
-    anchor: {
-      coords: {
-        x: 250,
-        y: 250,
-      }
-    }
-  }));
-  defaultOnboardingMessages.push(createBasicOnboardingMessage({
-    text: "This is the newly added onboarding message for the horizon chart. It's attached to a selector.",
-    title: "Selector attached message",
-    onboardingStage: newOnboardingStage,
-    anchor: {
-      sel: ".infolayer .ytitle"
-    }
-  }));
-  defaultOnboardingMessages.push(createBasicOnboardingMessage({
-    text: "This is the newly added onboarding message for the horizon chart. It's attached to a selector.",
-    title: "Element attached message",
-    onboardingStage: newOnboardingStage,
-    anchor: {
-      element: document.getElementsByClassName("section-title")[0]
-    }
-  }));
+  defaultOnboardingMessages[0].title = 'New stage';
+  defaultOnboardingMessages.push(
+    createBasicOnboardingMessage({
+      text: "This is the newly added onboarding message for the horizon chart. It's absolutely positioned.",
+      title: 'Absolutely positioned message',
+      onboardingStage: newOnboardingStage,
+      anchor: {
+        coords: {
+          x: 250,
+          y: 250,
+        },
+      },
+    }),
+  );
+  defaultOnboardingMessages.push(
+    createBasicOnboardingMessage({
+      text: "This is the newly added onboarding message for the horizon chart. It's attached to a selector.",
+      title: 'Selector attached message',
+      onboardingStage: newOnboardingStage,
+      anchor: {
+        sel: '.infolayer .ytitle',
+      },
+    }),
+  );
+  defaultOnboardingMessages.push(
+    createBasicOnboardingMessage({
+      text: "This is the newly added onboarding message for the horizon chart. It's attached to a selector.",
+      title: 'Element attached message',
+      onboardingStage: newOnboardingStage,
+      anchor: {
+        element: document.getElementsByClassName('section-title')[0],
+      },
+    }),
+  );
   // const newOnboardingMessage = createBasicOnboardingMessage();
   const ahoiConfig = {
     onboardingMessages: defaultOnboardingMessages,
     backdrop: {
-      show: false
-    }
-  }
+      show: false,
+    },
+  };
   return ahoiConfig;
-}
+};
 
 const registerEventListener = () => {
   showOnboarding = !showOnboarding;
-  const helpIcon = document.getElementById("show-onboarding");
-  if (!helpIcon) { return; }
+  const helpIcon = document.getElementById('show-onboarding');
+  if (!helpIcon) {
+    return;
+  }
   helpIcon.addEventListener('click', async () => {
     showOnboarding = !showOnboarding;
     if (showOnboarding) {
-      onboardingUI = await ahoi(EVisualizationType.HORIZON_GRAPH, chart, getAhoiConfig());
+      onboardingUI = await ahoi(
+        EVisualizationType.HORIZON_GRAPH,
+        chart,
+        getAhoiConfig(),
+      );
     } else {
       onboardingUI?.removeOnboarding();
     }
-  })
-}
+  });
+};
 
 registerEventListener();
 render();

--- a/packages/plotly-demo/src/scatterplot.js
+++ b/packages/plotly-demo/src/scatterplot.js
@@ -1,92 +1,105 @@
-import Plotly from 'plotly.js-dist'
-import { generateBasicAnnotations, ahoi, EVisualizationType } from '@visahoi/plotly';
-import debounce from "lodash.debounce";
+import Plotly from 'plotly.js-dist';
+import {
+  generateBasicAnnotations,
+  ahoi,
+  EVisualizationType,
+} from '@visahoi/plotly';
+import debounce from 'lodash.debounce';
 
 let chart = null;
 let showOnboarding = false;
 let onboardingUI = null;
 
 const debouncedResize = debounce((event) => {
-  onboardingUI?.updateOnboarding(getAhoiConfig())
+  onboardingUI?.updateOnboarding(getAhoiConfig());
 }, 250);
 
 async function render() {
   const response = await fetch('../data/cars.json');
   const data = await response.json();
-  const {x, y} = processData(data);
+  const { x, y } = processData(data);
   chart = await makePlotly(x, y);
-  window.addEventListener("resize", debouncedResize);
+  window.addEventListener('resize', debouncedResize);
 }
 
 function processData(allRows) {
-  const x = Object.values(allRows).map((d) => d["Horsepower"]);
-  const y = Object.values(allRows).map((d) => d["Miles_per_Gallon"]);
-  return {x, y};
+  const x = Object.values(allRows).map((d) => d['Horsepower']);
+  const y = Object.values(allRows).map((d) => d['Miles_per_Gallon']);
+  return { x, y };
 }
 
 function makePlotly(x, y) {
-  document.getElementById("plot");
+  document.getElementById('plot');
   const traces = [
     {
-      type: "scatter",
-      mode: "markers",
+      type: 'scatter',
+      mode: 'markers',
       x,
       y,
       marker: {
-        size: 5
-      }
-    }
+        size: 5,
+      },
+    },
   ];
 
   const layout = {
-    title: "Some title of cars or something",
+    title: 'Some title of cars or something',
     xaxis: {
-      title: "Horsepower",
+      title: 'Horsepower',
     },
     yaxis: {
-      title: "Miles per Gallon"
-    }
+      title: 'Miles per Gallon',
+    },
   };
 
   const config = {
-    responsive: true
+    responsive: true,
   };
 
-  return Plotly.newPlot("vis", traces, layout, config);
+  return Plotly.newPlot('vis', traces, layout, config);
 }
 
-const getAhoiConfig = () => {  
-  const defaultOnboardingMessages = generateBasicAnnotations(EVisualizationType.SCATTERPLOT, chart);
-  const extendedOnboardingMessages = defaultOnboardingMessages.map((message) => ({
-    ...message,
-    marker: {
-      ...message.marker,
-      fontSize: '12px',
-      radius: 10
-    }
-  }));
-  
+const getAhoiConfig = () => {
+  const defaultOnboardingMessages = generateBasicAnnotations(
+    EVisualizationType.SCATTERPLOT,
+    chart,
+  );
+  const extendedOnboardingMessages = defaultOnboardingMessages.map(
+    (message) => ({
+      ...message,
+      marker: {
+        ...message.marker,
+        fontSize: '12px',
+        radius: 10,
+      },
+    }),
+  );
+
   const ahoiConfig = {
-    onboardingMessages: extendedOnboardingMessages    
-  }
-  
+    onboardingMessages: extendedOnboardingMessages,
+  };
+
   return ahoiConfig;
-}
+};
 
 const registerEventListener = () => {
-  
-  const helpIcon = document.getElementById("show-onboarding");
-  if(!helpIcon) { return; }
+  const helpIcon = document.getElementById('show-onboarding');
+  if (!helpIcon) {
+    return;
+  }
   helpIcon.addEventListener('click', async () => {
     showOnboarding = !showOnboarding;
-    if(showOnboarding) {
-      onboardingUI = await ahoi(EVisualizationType.SCATTERPLOT, chart, getAhoiConfig());
+    if (showOnboarding) {
+      onboardingUI = await ahoi(
+        EVisualizationType.SCATTERPLOT,
+        chart,
+        getAhoiConfig(),
+      );
     } else {
       onboardingUI?.removeOnboarding();
     }
-    
-  })
-}
+  });
+};
 
 registerEventListener();
 render();

--- a/packages/plotly-demo/src/treeMap.js
+++ b/packages/plotly-demo/src/treeMap.js
@@ -56,7 +56,7 @@ const makePlotly = (label, parent, value, color) => {
     responsive: true,
   };
   const layout = {
-    // title: 'Jobs Plan',
+    title: 'Jobs Plan',
   };
   return Plotly.newPlot('vis', traces, layout, config);
 };

--- a/packages/plotly-demo/src/treeMap.js
+++ b/packages/plotly-demo/src/treeMap.js
@@ -1,6 +1,10 @@
 import Plotly from 'plotly.js-dist';
-import { generateBasicAnnotations, ahoi, EVisualizationType } from '@visahoi/plotly';
-import debounce from "lodash.debounce";
+import {
+  generateBasicAnnotations,
+  ahoi,
+  EVisualizationType,
+} from '@visahoi/plotly';
+import debounce from 'lodash.debounce';
 import { importCsv } from './util';
 
 let chart = null;
@@ -8,80 +12,88 @@ let showOnboarding = false;
 let onboardingUI = null;
 
 const debouncedResize = debounce((event) => {
-  onboardingUI?.updateOnboarding(getAhoiConfig())
+  onboardingUI?.updateOnboarding(getAhoiConfig());
 }, 250);
 
 const render = async () => {
-const data = await importCsv("./data/jobsPlan.csv");  
-  const {label, parent, value, color} = processData(data);
+  const data = await importCsv('./data/jobsPlan.csv');
+  const { label, parent, value, color } = processData(data);
   chart = await makePlotly(label, parent, value, color);
   window.addEventListener('resize', debouncedResize);
-}
+};
 
 const processData = (data) => {
-    const label = [];
-    const parent = [];
-    const value = [];
-    const color = [];
+  const label = [];
+  const parent = [];
+  const value = [];
+  const color = [];
 
-    data.map((d) => {
-        label.push(d.Label);
-        parent.push(d.Parent);
-        value.push(d.Value);
-        color.push(d.Color)
-    });
+  data.map((d) => {
+    label.push(d.Label);
+    parent.push(d.Parent);
+    value.push(d.Value);
+    color.push(d.Color);
+  });
 
-  return {label, parent, value, color};
-}
+  return { label, parent, value, color };
+};
 
 const makePlotly = (label, parent, value, color) => {
-    const traces = [
-        {
-            type: 'treemap',
-            branchvalues: "total",
-            labels: label,
-            parents: parent,
-            values: value,
-            marker: {
-                colors: color,
-                // colorscale: 'Greys',
-                      
-            },          
-        }
-    ];
-    const config = {
-        responsive: true
-    };
-    const layout = {
-        title: 'Jobs Plan'
-    };
-    return Plotly.newPlot('vis', traces, layout, config)
-}
+  const traces = [
+    {
+      type: 'treemap',
+      branchvalues: 'total',
+      labels: label,
+      parents: parent,
+      values: value,
+      marker: {
+        colors: color,
+        // colorscale: 'Greys',
+      },
+    },
+  ];
+  const config = {
+    responsive: true,
+  };
+  const layout = {
+    // title: 'Jobs Plan'
+  };
+  return Plotly.newPlot('vis', traces, layout, config);
+};
 
 const getAhoiConfig = () => {
-    const defaultOnboardingMessages = generateBasicAnnotations(EVisualizationType.TREEMAP, chart);
-    const extendedOnboardingMessages = defaultOnboardingMessages.map((d) => ({
-      ...d,
-      text: "test123"
-    }));
-    const ahoiConfig = {
-      onboardingMessages: defaultOnboardingMessages,
-    }
-    return ahoiConfig;
-  }
+  const defaultOnboardingMessages = generateBasicAnnotations(
+    EVisualizationType.TREEMAP,
+    chart,
+  );
+  const extendedOnboardingMessages = defaultOnboardingMessages.map((d) => ({
+    ...d,
+    text: 'test123',
+  }));
+  const ahoiConfig = {
+    onboardingMessages: defaultOnboardingMessages,
+  };
+  return ahoiConfig;
+};
 
-  const registerEventListener = () => {    
-    const helpIcon = document.getElementById("show-onboarding");
-    if(!helpIcon) { return; }
-    helpIcon.addEventListener('click', async () => {
-      showOnboarding = !showOnboarding;      
-      if(showOnboarding) {      
-        onboardingUI = await ahoi(EVisualizationType.TREEMAP, chart, getAhoiConfig());
-      } else {
-        onboardingUI?.removeOnboarding();
-      }      
-    })
+const registerEventListener = () => {
+  const helpIcon = document.getElementById('show-onboarding');
+  if (!helpIcon) {
+    return;
   }
+  helpIcon.addEventListener('click', async () => {
+    showOnboarding = !showOnboarding;
+    if (showOnboarding) {
+      onboardingUI = await ahoi(
+        EVisualizationType.TREEMAP,
+        chart,
+        getAhoiConfig(),
+      );
+    } else {
+      onboardingUI?.removeOnboarding();
+    }
+  });
+};
 
 registerEventListener();
 render();

--- a/packages/plotly-demo/src/treeMap.js
+++ b/packages/plotly-demo/src/treeMap.js
@@ -56,7 +56,7 @@ const makePlotly = (label, parent, value, color) => {
     responsive: true,
   };
   const layout = {
-    // title: 'Jobs Plan'
+    // title: 'Jobs Plan',
   };
   return Plotly.newPlot('vis', traces, layout, config);
 };

--- a/packages/plotly/src/bar-chart.ts
+++ b/packages/plotly/src/bar-chart.ts
@@ -15,17 +15,17 @@ function extractOnboardingSpec(chart: any, coords): IOnboardingBarChartSpec {
 
   return {
     chartTitle: {
-      value: chart.layout.title.text,
+      value: chart?.layout?.title?.text,
       anchor: {
         findDomNodeByValue: true,
-        offset: {left: -20, top: 10}
-      }
+        offset: { left: -20, top: 10 },
+      },
     },
     type: {
       value: t.type,
       anchor: {
-        sel: '.bars > .points > .point:nth-child(4)',
-      }
+        sel: ".bars > .points > .point:nth-child(4)",
+      },
     },
     orientation: {
       value: t.orientation === "v" ? "vertical" : "horizontal",
@@ -42,12 +42,14 @@ function extractOnboardingSpec(chart: any, coords): IOnboardingBarChartSpec {
     yMin: {
       value: t._extremes.y.min[0].val.toFixed(1), // 0 = first trace
       anchor: {
-        sel: '.bars > .points > .point:nth-child(2)',      }
+        sel: ".bars > .points > .point:nth-child(2)",
+      },
     },
     yMax: {
       value: t._extremes.y.max[0].val.toFixed(1),
       anchor: {
-        sel: '.bars > .points > .point:nth-child(7)',      }
+        sel: ".bars > .points > .point:nth-child(7)",
+      },
     },
     xMin: {
       value: t._extremes.x.min[0].val, // 0 = first trace
@@ -59,23 +61,31 @@ function extractOnboardingSpec(chart: any, coords): IOnboardingBarChartSpec {
       value: chart.layout.xaxis.title.text,
       anchor: {
         findDomNodeByValue: true,
-        offset: {left: -20, bottom: 10}
-      }
+        offset: { left: -20, bottom: 10 },
+      },
     },
     yAxisTitle: {
       value: chart.layout.yaxis.title.text,
       anchor: {
-        sel: '.infolayer .ytitle',
-        offset: {top: -25, right: 10}
-      }
-    }
+        sel: ".infolayer .ytitle",
+        offset: { top: -25, right: 10 },
+      },
+    },
     // xAxisLabel (e.g. 01, 02, …)
     // yAxisLabel (e.g. -5, 0, 5, ...)
     // Title (Average Temperature in Oslo)
   };
 }
 
-export function barChartFactory(chart: Element, coords, visElementId: Element): IOnboardingMessage[] {
+export function barChartFactory(
+  chart: Element,
+  coords,
+  visElementId: Element
+): IOnboardingMessage[] {
   const onbordingSpec = extractOnboardingSpec(chart, coords);
-  return generateMessages(EVisualizationType.BAR_CHART, onbordingSpec, visElementId);
+  return generateMessages(
+    EVisualizationType.BAR_CHART,
+    onbordingSpec,
+    visElementId
+  );
 }

--- a/packages/plotly/src/change-matrix.ts
+++ b/packages/plotly/src/change-matrix.ts
@@ -1,4 +1,3 @@
-
 import {
   EVisualizationType,
   IOnboardingMessage,
@@ -6,29 +5,34 @@ import {
   generateMessages,
 } from "@visahoi/core";
 
-function extractOnboardingSpec(chart: any, coords): IOnboardingChangeMatrixSpec {
-  const heatmapData = (<any>Array.from(<NodeList>chart.querySelectorAll(".hm"))[0]).__data__;
+function extractOnboardingSpec(
+  chart: any,
+  coords
+): IOnboardingChangeMatrixSpec {
+  const heatmapData = (<any>(
+    Array.from(<NodeList>chart.querySelectorAll(".hm"))[0]
+  )).__data__;
   const t = heatmapData[0].trace;
 
   return {
     chartTitle: {
-      value: chart.layout.title.text,
+      value: chart?.layout?.title?.text,
       anchor: {
         findDomNodeByValue: true,
-        offset: {left: -20, top: 10}
-      }
+        offset: { left: -20, top: 10 },
+      },
     },
     type: {
       value: t.type,
       anchor: {
-        sel: '.heatmaplayer > .hm > image'
-      }
+        sel: ".heatmaplayer > .hm > image",
+      },
     },
     legendTitle: {
       value: t.colorbar.title.text,
       anchor: {
-        sel: '.infolayer > .colorbar',
-        offset: {top: -10}
+        sel: ".infolayer > .colorbar",
+        offset: { top: -10 },
       },
     },
     yMin: {
@@ -47,14 +51,14 @@ function extractOnboardingSpec(chart: any, coords): IOnboardingChangeMatrixSpec 
       value: chart.layout.xaxis.title.text,
       anchor: {
         findDomNodeByValue: true,
-        offset: {left: -20}
-      }
+        offset: { left: -20 },
+      },
     },
     yAxis: {
       value: chart.layout.yaxis.title.text,
       anchor: {
-        sel: '.infolayer .ytitle'
-      }
+        sel: ".infolayer .ytitle",
+      },
     },
     // xAxisLabel (e.g. 01, 02, …)
     // yAxisLabel (e.g. -5, 0, 5, ...)
@@ -62,7 +66,15 @@ function extractOnboardingSpec(chart: any, coords): IOnboardingChangeMatrixSpec 
   };
 }
 
-export function changeMatrixFactory(chart, coords, visElementId: Element): IOnboardingMessage[] {
+export function changeMatrixFactory(
+  chart,
+  coords,
+  visElementId: Element
+): IOnboardingMessage[] {
   const onbordingSpec = extractOnboardingSpec(chart, coords);
-  return generateMessages(EVisualizationType.CHANGE_MATRIX, onbordingSpec, visElementId);
+  return generateMessages(
+    EVisualizationType.CHANGE_MATRIX,
+    onbordingSpec,
+    visElementId
+  );
 }

--- a/packages/plotly/src/horizon-graph.ts
+++ b/packages/plotly/src/horizon-graph.ts
@@ -1,4 +1,3 @@
-
 import {
   EVisualizationType,
   IOnboardingMessage,
@@ -6,42 +5,49 @@ import {
   generateMessages,
 } from "@visahoi/core";
 
-function extractOnboardingSpec(chart: any, coords): IOnboardingHorizonGraphSpec {
+function extractOnboardingSpec(
+  chart: any,
+  coords
+): IOnboardingHorizonGraphSpec {
   // from https://github.com/plotly/plotly.js/blob/bff79dc5e76739f674ac3d4c41b63b0fbd6f2ebc/test/jasmine/tests/bar_test.js
   const traceNodes = chart.querySelectorAll("g.fills");
   const areaNodes = traceNodes[0].querySelectorAll("path.js-fill");
-  const areaNodesData = Array.from(areaNodes).map((point: any) => point.__data__);
+  const areaNodesData = Array.from(areaNodes).map(
+    (point: any) => point.__data__
+  );
 
   const t = areaNodesData[0][0].trace;
-  
-  if (t === undefined || t === null)  {
-    console.error('Error: The trace is null or undefined, therefore not all onboarding messages can be shown.');    
-    return {      
+
+  if (t === undefined || t === null) {
+    console.error(
+      "Error: The trace is null or undefined, therefore not all onboarding messages can be shown."
+    );
+    return {
       chartTitle: {
-        value: chart.layout.title.text,
+        value: chart?.layout?.title?.text,
         anchor: {
           findDomNodeByValue: true,
-          offset: {left: -20, top: 10}
-        }
+          offset: { left: -20, top: 10 },
+        },
       },
+    };
   }
-}
 
   return {
     chartTitle: {
-      value: chart.layout.title.text,
+      value: chart?.layout?.title?.text,
       anchor: {
         findDomNodeByValue: true,
-        offset: {left: -20, top: 10}
-      }
+        offset: { left: -20, top: 10 },
+      },
     },
     type: {
       value: "area",
       anchor: {
         coords: {
-          x: (t._polygons[0].xmax / 2),
+          x: t._polygons[0].xmax / 2,
           y: t._polygons[0].ymax,
-        }
+        },
       },
     },
     // yMin: {
@@ -60,16 +66,16 @@ function extractOnboardingSpec(chart: any, coords): IOnboardingHorizonGraphSpec 
       value: chart.layout.xaxis.title.text,
       anchor: {
         coords: {
-          x: (t._polygons[0].xmax / 3*2),
-          y: (t._polygons[0].ymax / 3*2),
-        }
-      }
+          x: (t._polygons[0].xmax / 3) * 2,
+          y: (t._polygons[0].ymax / 3) * 2,
+        },
+      },
     },
     yAxis: {
       value: chart.layout.yaxis.title.text,
       anchor: {
-        sel: '.infolayer .ytitle',
-      }
+        sel: ".infolayer .ytitle",
+      },
     },
     // xAxisLabel (e.g. 01, 02, …)
     // yAxisLabel (e.g. -5, 0, 5, ...)
@@ -77,7 +83,15 @@ function extractOnboardingSpec(chart: any, coords): IOnboardingHorizonGraphSpec 
   };
 }
 
-export function horizonGraphFactory(chart, coords, visElementId: Element): IOnboardingMessage[] {
-  const onbordingSpec = extractOnboardingSpec(chart, coords);  
-  return generateMessages(EVisualizationType.HORIZON_GRAPH, onbordingSpec, visElementId);
+export function horizonGraphFactory(
+  chart,
+  coords,
+  visElementId: Element
+): IOnboardingMessage[] {
+  const onbordingSpec = extractOnboardingSpec(chart, coords);
+  return generateMessages(
+    EVisualizationType.HORIZON_GRAPH,
+    onbordingSpec,
+    visElementId
+  );
 }

--- a/packages/plotly/src/scatterplot.ts
+++ b/packages/plotly/src/scatterplot.ts
@@ -1,17 +1,24 @@
-import { EVisualizationType, IOnboardingMessage, generateMessages } from "@visahoi/core";
+import {
+  EVisualizationType,
+  IOnboardingMessage,
+  generateMessages,
+} from "@visahoi/core";
 import { IOnboardingScatterplotSpec } from "@visahoi/core/src/scatterplot";
 
 function extractOnboardingSpec(chart: any, coords): IOnboardingScatterplotSpec {
   const traceNodes = chart.querySelectorAll("g.points");
   const areaNodes = traceNodes[0].querySelectorAll("path.point");
-  const areaNodesData = Array.from(areaNodes).map((point: any) => point.__data__);
+  const areaNodesData = Array.from(areaNodes).map(
+    (point: any) => point.__data__
+  );
   const t = areaNodesData[0].trace;
 
   const grid = document
     .getElementsByClassName("nsewdrag drag")[0]
     .getBoundingClientRect();
 
-  const points = (Array.from(areaNodes)as any[]).filter((point) =>
+  const points = (Array.from(areaNodes) as any[]).filter(
+    (point) =>
       point.getBoundingClientRect().x &&
       point.getBoundingClientRect().x <= grid.width + grid.x &&
       point.getBoundingClientRect().y &&
@@ -27,42 +34,51 @@ function extractOnboardingSpec(chart: any, coords): IOnboardingScatterplotSpec {
 
   return {
     chartTitle: {
-      value: chart.layout.title.text,
+      value: chart?.layout?.title?.text,
       anchor: {
         findDomNodeByValue: true,
-        offset: {left: -20, top: 10}
-      }
+        offset: { left: -20, top: 10 },
+      },
     },
     type: {
       value: t.type,
       anchor: {
-        sel: '.points > .point:nth-child(4)' }
+        sel: ".points > .point:nth-child(4)",
+      },
     },
     xAxisTitle: {
       value: chart.layout.xaxis.title.text,
       anchor: {
-        sel: '.infolayer .xtitle',
-        offset: {left: -20}
-      }
+        sel: ".infolayer .xtitle",
+        offset: { left: -20 },
+      },
     },
     yAxisTitle: {
       value: chart.layout.yaxis.title.text,
       anchor: {
-        sel: '.infolayer .ytitle',
-        offset: {top: -25}
-      }
+        sel: ".infolayer .ytitle",
+        offset: { top: -25 },
+      },
     },
     maxValue: {
       value: maxX,
       anchor: {
-        coords: {x: maxX, y: maxY},
-        offset: {left: 25}
-      }
-  }
+        coords: { x: maxX, y: maxY },
+        offset: { left: 25 },
+      },
+    },
   };
 }
 
-export function scatterplotFactory(chart: Element, coords, visElementId: Element): IOnboardingMessage[] {
+export function scatterplotFactory(
+  chart: Element,
+  coords,
+  visElementId: Element
+): IOnboardingMessage[] {
   const onbordingSpec = extractOnboardingSpec(chart, coords);
-  return generateMessages(EVisualizationType.SCATTERPLOT, onbordingSpec, visElementId);
+  return generateMessages(
+    EVisualizationType.SCATTERPLOT,
+    onbordingSpec,
+    visElementId
+  );
 }

--- a/packages/plotly/src/treemap.ts
+++ b/packages/plotly/src/treemap.ts
@@ -1,146 +1,163 @@
 import {
-    EVisualizationType,
-    IOnboardingMessage,
-    IOnboardingTreemapSpec,
-    generateMessages,
-  } from "@visahoi/core";
-  
-  function extractOnboardingSpec(chart: any, coords): IOnboardingTreemapSpec {    
-  
+  EVisualizationType,
+  IOnboardingMessage,
+  IOnboardingTreemapSpec,
+  generateMessages,
+} from "@visahoi/core";
+
+function extractOnboardingSpec(chart: any, coords): IOnboardingTreemapSpec {
   let indexArr: number[] = [];
   let valArr: number[] = [];
-  let childArr: any =[];
+  let childArr: any = [];
   let maxIndex: number;
   let minIndex: number;
-  let maxLabel: string= '';
-  let minLabel: string= '';  
-  let parentLabel: string = '';
- 
-// set the parent for getting the max and min values of the sub-category
-  chart.data.map((d) => { if(d.parents.length > 1) {
-    if ( d.parents[0] === '' && d.parents.length >2) {
-     parentLabel = d.parents[1]; } else {  parentLabel = d.parents[0] } }  });
+  let maxLabel: string = "";
+  let minLabel: string = "";
+  let parentLabel: string = "";
 
-  
-// To get the min and max values and corresponding labels in each sub-category
-    
+  // set the parent for getting the max and min values of the sub-category
+  chart.data.map((d) => {
+    if (d.parents.length > 1) {
+      if (d.parents[0] === "" && d.parents.length > 2) {
+        parentLabel = d.parents[1];
+      } else {
+        parentLabel = d.parents[0];
+      }
+    }
+  });
+
+  // To get the min and max values and corresponding labels in each sub-category
 
   chart.data.map((dat: any, i: number) => {
-    dat.parents.map((parent: any, j: number) => {      
-      if(parent === parentLabel) {
-        indexArr.push(j);  
-       }      
+    dat.parents.map((parent: any, j: number) => {
+      if (parent === parentLabel) {
+        indexArr.push(j);
+      }
     });
-   
-    dat.values.map((value: number, id: number) => {
-      if(indexArr) {
-        indexArr.map((d) => {
-          if(d === id) {          
-            childArr.push({value: value,
-            index: id});
-            valArr.push(value);           
-          }
-        })        
-      }      
-    });      
-  });  
-  
-  const maxVal = Math.max.apply(Math, valArr);
-  const minVal = Math.min.apply(Math, valArr);  
-  
 
-  childArr.map((dd:any, i: number) => {    
-    if(parseInt(dd.value) === maxVal) {      
+    dat.values.map((value: number, id: number) => {
+      if (indexArr) {
+        indexArr.map((d) => {
+          if (d === id) {
+            childArr.push({ value: value, index: id });
+            valArr.push(value);
+          }
+        });
+      }
+    });
+  });
+
+  const maxVal = Math.max.apply(Math, valArr);
+  const minVal = Math.min.apply(Math, valArr);
+
+  childArr.map((dd: any, i: number) => {
+    if (parseInt(dd.value) === maxVal) {
       maxIndex = dd.index;
     }
-    if(parseInt(dd.value) === minVal) {      
-      minIndex = dd.index;      
+    if (parseInt(dd.value) === minVal) {
+      minIndex = dd.index;
     }
-  })
-  
-  chart.data.map((d: any) => d.labels.map((label: string, i:number ) => {
-    if(i === maxIndex) {
-      maxLabel = label;
-    }
-    if(i === minIndex) {
-      minLabel = label;
-    }
-  }));   
-  
-    return {
-      chartTitle: {        
-        value: chart.layout.title.text,
-        anchor: {
-          findDomNodeByValue: true,
-          offset: {left: -20, top: 10}
-        }
-      },
+  });
 
-      desc: {        
-        value: chart.data[0].labels[0],
-        anchor: {
-          findDomNodeByValue: true,
-          offset: {left: -20, top: 20}
-        }
-      },
+  chart.data.map((d: any) =>
+    d.labels.map((label: string, i: number) => {
+      if (i === maxIndex) {
+        maxLabel = label;
+      }
+      if (i === minIndex) {
+        minLabel = label;
+      }
+    })
+  );
 
-      subDesc: {
-        // value: chart.data[0].labels[17],
-        value: (chart.data[0].labels[1]) ? chart.data[0].labels[1] : chart.data[0].labels[0],
-        anchor: {
-          findDomNodeByValue: true,
-          offset: {left: -40, top:-30}
-        }
+  return {
+    chartTitle: {
+      value: chart?.layout?.title?.text,
+      anchor: {
+        findDomNodeByValue: true,
+        offset: { left: -20, top: 10 },
       },
+    },
 
-      gapDesc: {
-        value: (chart.data[0].labels[3]) ? chart.data[0].labels[3] : chart.data[0].labels[0] ,
-        anchor: {
-          findDomNodeByValue: true,
-          offset: {left: -40, top:-60}
-        }
+    desc: {
+      value: chart.data[0].labels[0],
+      anchor: {
+        findDomNodeByValue: true,
+        offset: { left: -20, top: 20 },
       },
+    },
 
-      otherDesc: {
-        value: (chart.data[0].labels[2]) ? chart.data[0].labels[2] : chart.data[0].labels[1] ? chart.data[0].labels[1]: chart.data[0].labels[0],
-        anchor: {
-          findDomNodeByValue: true,
-          offset: {left: -80, top: -30}
-        }
+    subDesc: {
+      // value: chart.data[0].labels[17],
+      value: chart.data[0].labels[1]
+        ? chart.data[0].labels[1]
+        : chart.data[0].labels[0],
+      anchor: {
+        findDomNodeByValue: true,
+        offset: { left: -40, top: -30 },
       },
-      interactingDesc:{
-        value: chart.data[0].labels[0],
-        anchor: {
-          findDomNodeByValue: true,
-          offset: {left: -20, top: -30}
-        }
+    },
+
+    gapDesc: {
+      value: chart.data[0].labels[3]
+        ? chart.data[0].labels[3]
+        : chart.data[0].labels[0],
+      anchor: {
+        findDomNodeByValue: true,
+        offset: { left: -40, top: -60 },
       },
-      maxValueDesc: {        
-        value: maxLabel,
-        anchor: {
-          findDomNodeByValue: true,
-          offset: {left: -20, top: -30}
-        }
+    },
+
+    otherDesc: {
+      value: chart.data[0].labels[2]
+        ? chart.data[0].labels[2]
+        : chart.data[0].labels[1]
+        ? chart.data[0].labels[1]
+        : chart.data[0].labels[0],
+      anchor: {
+        findDomNodeByValue: true,
+        offset: { left: -80, top: -30 },
       },
-      minValueDesc: {        
-        value: minLabel,
-        anchor: {
-          findDomNodeByValue: true,
-          offset: {left: -20, top: -20}
-        }
+    },
+    interactingDesc: {
+      value: chart.data[0].labels[0],
+      anchor: {
+        findDomNodeByValue: true,
+        offset: { left: -20, top: -30 },
       },
-      maxValue: {
-        value: maxVal,        
+    },
+    maxValueDesc: {
+      value: maxLabel,
+      anchor: {
+        findDomNodeByValue: true,
+        offset: { left: -20, top: -30 },
       },
-      minValue: {
-        value: minVal
-      }  
-     
-    };
-  }
-  
-  export function treemapFactory(chart: Element, coords, visElementId: Element): IOnboardingMessage[] {
-    const onbordingSpec = extractOnboardingSpec(chart, coords);
-    return generateMessages(EVisualizationType.TREEMAP, onbordingSpec, visElementId);
-  }
-  
+    },
+    minValueDesc: {
+      value: minLabel,
+      anchor: {
+        findDomNodeByValue: true,
+        offset: { left: -20, top: -20 },
+      },
+    },
+    maxValue: {
+      value: maxVal,
+    },
+    minValue: {
+      value: minVal,
+    },
+  };
+}
+
+export function treemapFactory(
+  chart: Element,
+  coords,
+  visElementId: Element
+): IOnboardingMessage[] {
+  const onbordingSpec = extractOnboardingSpec(chart, coords);
+  return generateMessages(
+    EVisualizationType.TREEMAP,
+    onbordingSpec,
+    visElementId
+  );
+}


### PR DESCRIPTION
closes #114 
Summary:
* In the core package of each chart, where the messages are added, it is checked whether the chart has title if not 'chartTitle' is not added to the message.

screenshots:
![image](https://user-images.githubusercontent.com/104566246/177737534-a4b979c3-0c65-42a5-bbfd-c2b01339bfb0.png)
