### PR TITLE
Delete onboarding stages

### DIFF
--- a/packages/core/src/components/OnboardingNavigationItem.svelte
+++ b/packages/core/src/components/OnboardingNavigationItem.svelte
@@ -8,11 +8,11 @@
   export let stage: IOnboardingStage;
   export let index: number;
 
+  const bottom: string = (index + 1) * 75 + "px";
+
   const handleClick = () => {
     activeOnboardingStage.update((v) => (v?.id === stage.id ? null : stage));
   };
-
-  const bottom: string = (index + 1) * 75 + "px";
 </script>
 
 <div

--- a/packages/core/src/components/OnboardingNavigationMainItem.svelte
+++ b/packages/core/src/components/OnboardingNavigationMainItem.svelte
@@ -5,6 +5,8 @@
     showHideCloseText,
     showOnboardingNavigation,
     isEditModeActive,
+    onboardingStages,
+    markerInformation,
   } from "./stores.js";
   import { navigationMainItemDefaultColor } from "../constants";
 
@@ -25,6 +27,29 @@
   const toggleEditMode = () => {
     isEditModeActive.set(!$isEditModeActive);
   };
+
+  const deleteOnboardingStage = () => {
+    const tempOnboardingStages = $onboardingStages;
+
+    tempOnboardingStages.map((onboardingStage, i) => {
+      if (onboardingStage.id === $activeOnboardingStage?.id) {
+        tempOnboardingStages.splice(i, 1);
+      }
+
+      const tempMarkerInformation = $markerInformation.filter(
+        (m) => m.message.onboardingStage.id !== $activeOnboardingStage?.id
+      );
+
+      markerInformation.set(tempMarkerInformation);
+      onboardingStages.set(tempOnboardingStages);
+
+      if ($onboardingStages.length === 0) {
+        console.error(
+          "No onboarding stages available. It seems that you have deleted all the onboarding stages."
+        );
+      }
+    });
+  };
 </script>
 
 <div class="visahoi-navigation-main-item" on:click={handleClick}>
@@ -37,6 +62,12 @@
       <span><i class="fas fa-times" /></span>
     {:else}
       <span><i class="fas fa-question" /></span>
+    {/if}
+
+    {#if $activeOnboardingStage}
+      <div class="visahoi-delete-stage" on:click={deleteOnboardingStage}>
+        <i class="fas fa-trash" />
+      </div>
     {/if}
   </div>
 
@@ -122,5 +153,18 @@
 
   .visahoi-stage-title {
     font-weight: bold;
+  }
+
+  .visahoi-delete-stage {
+    position: absolute;
+    margin-left: 110px;
+  }
+
+  /* .visahoi-delete-stage > i {
+    color: black;
+  } */
+
+  .fa-trash {
+    color: black;
   }
 </style>

--- a/packages/core/src/components/OnboardingNavigationMainItem.svelte
+++ b/packages/core/src/components/OnboardingNavigationMainItem.svelte
@@ -31,11 +31,12 @@
   const deleteOnboardingStage = () => {
     const tempOnboardingStages = $onboardingStages;
 
+    // The stage is removed from the array
     tempOnboardingStages.map((onboardingStage, i) => {
       if (onboardingStage.id === $activeOnboardingStage?.id) {
         tempOnboardingStages.splice(i, 1);
       }
-
+      // The onboarding messages for the stage is filtered out
       const tempMarkerInformation = $markerInformation.filter(
         (m) => m.message.onboardingStage.id !== $activeOnboardingStage?.id
       );
@@ -64,7 +65,7 @@
       <span><i class="fas fa-question" /></span>
     {/if}
 
-    {#if $activeOnboardingStage}
+    {#if $activeOnboardingStage && $isEditModeActive}
       <div class="visahoi-delete-stage" on:click={deleteOnboardingStage}>
         <i class="fas fa-trash" />
       </div>
@@ -92,7 +93,7 @@
       <i class="fas fa-solid fa-toggle-on" />
     </span>
   {:else}
-    <span class="test-span" on:click={toggleNavigation}>
+    <span on:click={toggleNavigation}>
       <i
         class="fas fa-solid fa-toggle-off"
         style="width: 20px, height:20px"

--- a/packages/core/src/components/Tooltip.svelte
+++ b/packages/core/src/components/Tooltip.svelte
@@ -125,7 +125,7 @@
     // Console message is shown when all the onboarding messages are delete
     if ($onboardingStages.length === 0) {
       console.error(
-        "No onboarding messages are available!!!. It seems that you have deleted all the onboarding messages"
+        "No onboarding stages are available. It seems that all onboarding stages have been deleted."
       );
     }
   };

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -70,6 +70,9 @@ export interface IAhoiConfig {
   backdrop: IBackdropConfig;
   showHelpCloseText?: boolean;
   showOnboardingNavigation: boolean;
+  deleteOnboardingStage: {
+    id: string;
+  };
 }
 
 export type TooltipPosition = "top" | "bottom" | "left" | "right";

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -70,9 +70,6 @@ export interface IAhoiConfig {
   backdrop: IBackdropConfig;
   showHelpCloseText?: boolean;
   showOnboardingNavigation: boolean;
-  deleteOnboardingStage: {
-    id: string;
-  };
 }
 
 export type TooltipPosition = "top" | "bottom" | "left" | "right";

--- a/packages/core/src/onboarding.ts
+++ b/packages/core/src/onboarding.ts
@@ -79,6 +79,16 @@ export const injectOnboarding = (
 
   const updateOnboarding = (config: IAhoiConfig) => {
     onboardingMessages.set(config.onboardingMessages);
+    // if (config.deleteOnboardingStage) {
+    //   console.log("It is ...");
+    //   const messages: IOnboardingMessage[] = get(onboardingMessages);
+    //   messages.map((m, i) => {
+    //     if (m.onboardingStage.id === ahoiConfig.deleteOnboardingStage.id) {
+    //       messages.splice(i, 1);
+    //     }
+    //   });
+    //   onboardingMessages.set(messages);
+    // }
     ref.update();
   };
 

--- a/packages/core/src/onboarding.ts
+++ b/packages/core/src/onboarding.ts
@@ -103,3 +103,17 @@ export const createBasicOnboardingMessage = (
   };
   return onboardingMessage;
 };
+
+export const deleteOnboardingStage = (id: string) => {
+  console.log("delete ...");
+  console.log(id, "Id");
+
+  const stages: IOnboardingStage[] = get(onboardingStages);
+  console.log(stages);
+  stages.map((m, i) => {
+    if (m.id === id) {
+      stages.splice(i, 1);
+    }
+  });
+  return onboardingStages.set(stages);
+};

--- a/packages/core/src/onboarding.ts
+++ b/packages/core/src/onboarding.ts
@@ -31,7 +31,6 @@ export const injectOnboarding = (
     const stages: IOnboardingStage[] = get(onboardingStages);
     const messages: IOnboardingMessage[] = get(onboardingMessages);
 
-    debugger;
     stages.map((m, i) => {
       if (m.id === ahoiConfig.deleteOnboardingStage.id) {
         stages.splice(i, 1);

--- a/packages/core/src/onboarding.ts
+++ b/packages/core/src/onboarding.ts
@@ -27,27 +27,6 @@ export const injectOnboarding = (
 ) => {
   onboardingMessages.set(ahoiConfig.onboardingMessages);
 
-  if (ahoiConfig?.deleteOnboardingStage) {
-    const stages: IOnboardingStage[] = get(onboardingStages);
-    const messages: IOnboardingMessage[] = get(onboardingMessages);
-
-    stages.map((m, i) => {
-      if (m.id === ahoiConfig.deleteOnboardingStage.id) {
-        stages.splice(i, 1);
-      }
-    });
-
-    // messages.map((m, i) => {
-    //   if (m.onboardingStage.id === ahoiConfig.deleteOnboardingStage.id) {
-    //     messages.splice(i, 1);
-    //   }
-    // });
-
-    onboardingStages.set(stages);
-    // onboardingMessages.set(messages);
-    // console.log(get(onboardingMessages), "Onboarding messages");
-  }
-
   if (ahoiConfig?.showOnboardingNavigation) {
     showOnboardingNavigation.set(ahoiConfig?.showOnboardingNavigation);
   }
@@ -55,9 +34,9 @@ export const injectOnboarding = (
   const stageIds = ahoiConfig.onboardingMessages.map(
     (m) => m.onboardingStage.id
   );
-  // onboardingStages.set([
-  //   ...new Set(ahoiConfig.onboardingMessages.map((m) => m.onboardingStage)),
-  // ]);
+  onboardingStages.set([
+    ...new Set(ahoiConfig.onboardingMessages.map((m) => m.onboardingStage)),
+  ]);
   navigationAlignment.set(alignment);
   if (
     ahoiConfig?.backdrop?.show !== null &&
@@ -79,16 +58,6 @@ export const injectOnboarding = (
 
   const updateOnboarding = (config: IAhoiConfig) => {
     onboardingMessages.set(config.onboardingMessages);
-    // if (config.deleteOnboardingStage) {
-    //   console.log("It is ...");
-    //   const messages: IOnboardingMessage[] = get(onboardingMessages);
-    //   messages.map((m, i) => {
-    //     if (m.onboardingStage.id === ahoiConfig.deleteOnboardingStage.id) {
-    //       messages.splice(i, 1);
-    //     }
-    //   });
-    //   onboardingMessages.set(messages);
-    // }
     ref.update();
   };
 

--- a/packages/core/src/onboarding.ts
+++ b/packages/core/src/onboarding.ts
@@ -34,9 +34,9 @@ export const injectOnboarding = (
   const stageIds = ahoiConfig.onboardingMessages.map(
     (m) => m.onboardingStage.id
   );
-  onboardingStages.set([
-    ...new Set(ahoiConfig.onboardingMessages.map((m) => m.onboardingStage)),
-  ]);
+  // onboardingStages.set([
+  //   ...new Set(ahoiConfig.onboardingMessages.map((m) => m.onboardingStage)),
+  // ]);
   navigationAlignment.set(alignment);
   if (
     ahoiConfig?.backdrop?.show !== null &&
@@ -105,11 +105,7 @@ export const createBasicOnboardingMessage = (
 };
 
 export const deleteOnboardingStage = (id: string) => {
-  console.log("delete ...");
-  console.log(id, "Id");
-
   const stages: IOnboardingStage[] = get(onboardingStages);
-  console.log(stages);
   stages.map((m, i) => {
     if (m.id === id) {
       stages.splice(i, 1);

--- a/packages/core/src/onboarding.ts
+++ b/packages/core/src/onboarding.ts
@@ -27,6 +27,28 @@ export const injectOnboarding = (
 ) => {
   onboardingMessages.set(ahoiConfig.onboardingMessages);
 
+  if (ahoiConfig?.deleteOnboardingStage) {
+    const stages: IOnboardingStage[] = get(onboardingStages);
+    const messages: IOnboardingMessage[] = get(onboardingMessages);
+
+    debugger;
+    stages.map((m, i) => {
+      if (m.id === ahoiConfig.deleteOnboardingStage.id) {
+        stages.splice(i, 1);
+      }
+    });
+
+    // messages.map((m, i) => {
+    //   if (m.onboardingStage.id === ahoiConfig.deleteOnboardingStage.id) {
+    //     messages.splice(i, 1);
+    //   }
+    // });
+
+    onboardingStages.set(stages);
+    // onboardingMessages.set(messages);
+    // console.log(get(onboardingMessages), "Onboarding messages");
+  }
+
   if (ahoiConfig?.showOnboardingNavigation) {
     showOnboardingNavigation.set(ahoiConfig?.showOnboardingNavigation);
   }
@@ -34,9 +56,9 @@ export const injectOnboarding = (
   const stageIds = ahoiConfig.onboardingMessages.map(
     (m) => m.onboardingStage.id
   );
-  onboardingStages.set([
-    ...new Set(ahoiConfig.onboardingMessages.map((m) => m.onboardingStage)),
-  ]);
+  // onboardingStages.set([
+  //   ...new Set(ahoiConfig.onboardingMessages.map((m) => m.onboardingStage)),
+  // ]);
   navigationAlignment.set(alignment);
   if (
     ahoiConfig?.backdrop?.show !== null &&

--- a/packages/plotly-demo/src/scatterplot.js
+++ b/packages/plotly-demo/src/scatterplot.js
@@ -78,9 +78,6 @@ const getAhoiConfig = () => {
   const ahoiConfig = {
     onboardingMessages: defaultOnboardingMessages,
     // showOnboardingNavigation: true,
-    deleteOnboardingStage: {
-      id: 'using-the-chart',
-    },
   };
 
   return ahoiConfig;

--- a/packages/plotly-demo/src/scatterplot.js
+++ b/packages/plotly-demo/src/scatterplot.js
@@ -10,6 +10,7 @@ import debounce from 'lodash.debounce';
 let chart = null;
 let showOnboarding = false;
 let onboardingUI = null;
+let deleteStageId = null;
 
 const debouncedResize = debounce((event) => {
   onboardingUI?.updateOnboarding(getAhoiConfig());
@@ -75,10 +76,19 @@ const getAhoiConfig = () => {
       },
     }),
   );
-  deleteOnboardingStage('reading-the-chart');
+
+  // To delete the onboarding stage
+  deleteStageId = 'reading-the-chart';
+  deleteOnboardingStage(deleteStageId);
 
   const ahoiConfig = {
-    onboardingMessages: defaultOnboardingMessages,
+    //Check whether the deleteStageId is defined if filter the onboarding messages with the deleted onboarding stage.
+
+    onboardingMessages: deleteStageId
+      ? defaultOnboardingMessages.filter(
+          (m) => m.onboardingStage.id !== deleteStageId,
+        )
+      : defaultOnboardingMessages,
     // showOnboardingNavigation: true,
   };
 

--- a/packages/plotly-demo/src/scatterplot.js
+++ b/packages/plotly-demo/src/scatterplot.js
@@ -3,6 +3,7 @@ import {
   generateBasicAnnotations,
   ahoi,
   EVisualizationType,
+  deleteOnboardingStage,
 } from '@visahoi/plotly';
 import debounce from 'lodash.debounce';
 
@@ -74,6 +75,7 @@ const getAhoiConfig = () => {
       },
     }),
   );
+  deleteOnboardingStage('reading-the-chart');
 
   const ahoiConfig = {
     onboardingMessages: defaultOnboardingMessages,

--- a/packages/plotly-demo/src/scatterplot.js
+++ b/packages/plotly-demo/src/scatterplot.js
@@ -78,6 +78,9 @@ const getAhoiConfig = () => {
   const ahoiConfig = {
     onboardingMessages: defaultOnboardingMessages,
     // showOnboardingNavigation: true,
+    deleteOnboardingStage: {
+      id: 'using-the-chart',
+    },
   };
 
   return ahoiConfig;

--- a/packages/plotly/src/index.ts
+++ b/packages/plotly/src/index.ts
@@ -7,6 +7,7 @@ import {
   createBasicOnboardingStage,
   createBasicOnboardingMessage,
   getOnboardingStages,
+  deleteOnboardingStage,
 } from "@visahoi/core";
 import { barChartFactory } from "./bar-chart";
 import { changeMatrixFactory } from "./change-matrix";
@@ -19,6 +20,7 @@ export {
   createBasicOnboardingMessage,
   createBasicOnboardingStage,
   getOnboardingStages,
+  deleteOnboardingStage,
 };
 
 /**


### PR DESCRIPTION
closes #128 
Summary:
* The onboarding stages can be deleted if Edit mode is active.
* The onboarding messages regarding the onboarding stage is also deleted.
Screenshots:
![image](https://user-images.githubusercontent.com/104566246/180723582-a307b492-9028-4404-8c32-596ee7d33723.png)
![image](https://user-images.githubusercontent.com/104566246/180723696-0d614d6d-3778-48d8-b9ae-79b72c083915.png)
![image](https://user-images.githubusercontent.com/104566246/180723803-825a229b-83c2-43ca-b131-053a17533ad0.png)

**The onboarding stages can also be deleted through deleteOnboardingStage by passing the id of the stage:**

![image](https://user-images.githubusercontent.com/104566246/181453066-226f2a49-4d77-4aea-9250-ce3e82bb17c2.png)
